### PR TITLE
Support for realtime alerts (enhanced feed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ gen-py/
 _site/
 /otp
 /otp-batch-analyst
+lucene/
+var/

--- a/src/main/java/org/opentripplanner/model/EnhancedAlert.java
+++ b/src/main/java/org/opentripplanner/model/EnhancedAlert.java
@@ -1,0 +1,81 @@
+package org.opentripplanner.model;
+
+import org.opentripplanner.routing.alertpatch.AlertPatch;
+import java.util.List;
+
+public class EnhancedAlert {
+    public enum AffectedActivity {
+        BOARD,
+        EXIT,
+        RIDE,
+        USING_ESCALATOR,
+        BRINGING_BIKE,
+        PARK_CAR,
+        STORE_BIKE,
+        USING_WHEELCHAIR
+    }
+
+    private FeedScopedId route;
+    private FeedScopedId stop;
+    private FeedScopedId trip;
+    private List<AffectedActivity> activities;
+
+    public FeedScopedId getRoute() {
+        return route;
+    }
+
+    public void setRoute(FeedScopedId route) {
+        this.route = route;
+    }
+
+    public FeedScopedId getStop() {
+        return stop;
+    }
+
+    public void setStop(FeedScopedId stop) {
+        this.stop = stop;
+    }
+
+    public FeedScopedId getTrip() {
+        return trip;
+    }
+
+    public void setTrip(FeedScopedId trip) {
+        this.trip = trip;
+    }
+
+    public List<AffectedActivity> getActivities() {
+        return activities;
+    }
+
+    public void setActivities(List<AffectedActivity> activities) {
+        this.activities = activities;
+    }
+
+    public EnhancedAlert() {}
+
+    public boolean appliesTo(AlertPatch alertPatch) {
+        if (this.route != null && !this.route.equals(alertPatch.getRoute())) {
+            return false;
+        } else if (this.stop != null && !this.stop.equals(alertPatch.getStop())) {
+            return false;
+        } else if (this.trip != null && !this.trip.equals(alertPatch.getTrip())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean cannotBoard() {
+        return activities.contains(AffectedActivity.BOARD);
+    }
+
+    public boolean cannotAlight() {
+        return activities.contains(AffectedActivity.EXIT);
+    }
+
+    public boolean cannotRideThrough() {
+        return activities.contains(AffectedActivity.RIDE);
+    }
+}
+

--- a/src/main/java/org/opentripplanner/model/EnhancedAlert.java
+++ b/src/main/java/org/opentripplanner/model/EnhancedAlert.java
@@ -55,11 +55,11 @@ public class EnhancedAlert {
     public EnhancedAlert() {}
 
     public boolean appliesTo(AlertPatch alertPatch) {
-        if (this.route != null && !this.route.equals(alertPatch.getRoute())) {
+        if (route != null && !route.equals(alertPatch.getRoute())) {
             return false;
-        } else if (this.stop != null && !this.stop.equals(alertPatch.getStop())) {
+        } else if (stop != null && !stop.equals(alertPatch.getStop())) {
             return false;
-        } else if (this.trip != null && !this.trip.equals(alertPatch.getTrip())) {
+        } else if (trip != null && !trip.equals(alertPatch.getTrip())) {
             return false;
         }
 

--- a/src/main/java/org/opentripplanner/routing/alertpatch/Alert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/Alert.java
@@ -1,5 +1,6 @@
 package org.opentripplanner.routing.alertpatch;
 
+import com.google.transit.realtime.GtfsRealtime;
 import org.opentripplanner.util.I18NString;
 import org.opentripplanner.util.NonLocalizedString;
 
@@ -31,15 +32,15 @@ public class Alert implements Serializable {
     @XmlElement
     public Date effectiveEndDate;
 
-    private String effectDetails;
+    private GtfsRealtime.Alert.Effect effect;
     private String id;
 
-    public String getEffectDetails() {
-        return effectDetails;
+    public GtfsRealtime.Alert.Effect getEffect() {
+        return effect;
     }
 
-    public void setEffectDetails(String effectDetails) {
-        this.effectDetails = effectDetails;
+    public void setEffect(GtfsRealtime.Alert.Effect effect) {
+        this.effect = effect;
     }
 
     public String getId() {

--- a/src/main/java/org/opentripplanner/routing/alertpatch/Alert.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/Alert.java
@@ -31,6 +31,25 @@ public class Alert implements Serializable {
     @XmlElement
     public Date effectiveEndDate;
 
+    private String effectDetails;
+    private String id;
+
+    public String getEffectDetails() {
+        return effectDetails;
+    }
+
+    public void setEffectDetails(String effectDetails) {
+        this.effectDetails = effectDetails;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
     public static HashSet<Alert> newSimpleAlertSet(String text) {
         Alert note = createSimpleAlerts(text);
         HashSet<Alert> notes = new HashSet<Alert>(1);

--- a/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
@@ -82,6 +82,15 @@ public class AlertPatch implements Serializable {
         return false;
     }
 
+    public boolean cannotRideThrough() {
+        return alert.getEffectDetails().equals("SUSPENSION");
+    }
+
+    public boolean cannotAlightOrBoard() {
+        String[] noBoarding = {"SUSPENSION", "STATION_CLOSURE", "STOP_CLOSURE", "DOCK_CLOSURE"};
+        return Arrays.asList(noBoarding).contains(alert.getEffectDetails());
+    }
+
     @XmlElement
     public String getId() {
         return id;
@@ -129,6 +138,12 @@ public class AlertPatch implements Serializable {
                         if (stop == null || stop.equals(tripPattern.stopPattern.stops[i])) {
                             graph.addAlertPatch(tripPattern.boardEdges[i], this);
                             graph.addAlertPatch(tripPattern.alightEdges[i], this);
+                        }
+                    }
+
+                    for (int i = 0; i < tripPattern.hopEdges.length; i++) {
+                        if (stop == null || stop.equals(tripPattern.hopEdges[i].getEndStop())) {
+                            graph.addAlertPatch(tripPattern.hopEdges[i], this);
                         }
                     }
                 }
@@ -190,6 +205,12 @@ public class AlertPatch implements Serializable {
                         if (stop == null || stop.equals(tripPattern.stopPattern.stops[i])) {
                             graph.removeAlertPatch(tripPattern.boardEdges[i], this);
                             graph.removeAlertPatch(tripPattern.alightEdges[i], this);
+                        }
+                    }
+
+                    for (int i = 0; i < tripPattern.hopEdges.length; i++) {
+                        if (stop == null || stop.equals(tripPattern.hopEdges[i].getEndStop())) {
+                            graph.removeAlertPatch(tripPattern.hopEdges[i], this);
                         }
                     }
                 }

--- a/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
@@ -36,6 +36,8 @@ public class AlertPatch implements Serializable {
 
     private String id;
 
+    private List<EnhancedAlert> enhancedAlerts;
+
     private Alert alert;
 
     private List<TimePeriod> timePeriods = new ArrayList<TimePeriod>();
@@ -81,7 +83,7 @@ public class AlertPatch implements Serializable {
 
     private boolean serviceAffected() {
         GtfsRealtime.Alert.Effect effect = getAlert().getEffect();
-        return effect.equals(GtfsRealtime.Alert.Effect.NO_SERVICE) || effect.equals(GtfsRealtime.Alert.Effect.DETOUR);
+        return GtfsRealtime.Alert.Effect.NO_SERVICE.equals(effect) || GtfsRealtime.Alert.Effect.DETOUR.equals(effect);
     }
 
     public boolean cannotRideThrough() {
@@ -104,8 +106,6 @@ public class AlertPatch implements Serializable {
     public void setId(String id) {
         this.id = id;
     }
-
-    private List<EnhancedAlert> enhancedAlerts;
 
     public List<EnhancedAlert> getEnhancedAlerts() {
         return enhancedAlerts;

--- a/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
@@ -36,7 +36,7 @@ public class AlertPatch implements Serializable {
 
     private String id;
 
-    private List<EnhancedAlert> enhancedAlerts;
+    private List<EnhancedAlert> enhancedAlerts = new ArrayList<>();
 
     private Alert alert;
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/PatternHop.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PatternHop.java
@@ -5,6 +5,7 @@ import org.opentripplanner.model.Stop;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.gtfs.GtfsLibrary;
+import org.opentripplanner.routing.alertpatch.AlertPatch;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -64,7 +65,13 @@ public class PatternHop extends TablePatternEdge implements OnboardEdge, HopEdge
                 return null;
             }
         }
-        
+
+        for (AlertPatch alertPatch: options.getRoutingContext().graph.getAlertPatches(this)) {
+            if (alertPatch.cannotRideThrough() && alertPatch.displayDuring(state0)) {
+                return null;
+            }
+        }
+
     	int runningTime = getPattern().scheduledTimetable.getBestRunningTime(stopIndex);
     	StateEditor s1 = state0.edit(this);
     	s1.incrementTimeInSeconds(runningTime);
@@ -90,6 +97,12 @@ public class PatternHop extends TablePatternEdge implements OnboardEdge, HopEdge
         if (!options.bannedStopsHard.isEmpty()) {
             if (options.bannedStopsHard.matches(((PatternStopVertex) fromv).getStop())
                     || options.bannedStopsHard.matches(((PatternStopVertex) tov).getStop())) {
+                return null;
+            }
+        }
+
+        for (AlertPatch alertPatch: options.getRoutingContext().graph.getAlertPatches(this)) {
+            if (alertPatch.cannotRideThrough() && alertPatch.displayDuring(s0)) {
                 return null;
             }
         }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
@@ -5,6 +5,7 @@ import java.util.BitSet;
 import java.util.Locale;
 import org.opentripplanner.model.Stop;
 import org.opentripplanner.model.Trip;
+import org.opentripplanner.routing.alertpatch.AlertPatch;
 import org.opentripplanner.routing.core.RoutingContext;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.ServiceDay;
@@ -132,7 +133,13 @@ public class TransitBoardAlight extends TablePatternEdge implements OnboardEdge 
         /* If the user requested a wheelchair accessible trip, check whether and this stop is not accessible. */
         if (options.wheelchairAccessible && ! getPattern().wheelchairAccessible(stopIndex)) {
             return null;
-        };
+        }
+
+        for (AlertPatch alertPatch: options.getRoutingContext().graph.getAlertPatches(this)) {
+            if (alertPatch.cannotAlightOrBoard() && alertPatch.displayDuring(s0)) {
+                return null;
+            }
+        }
 
         /*
          * Determine whether we are going onto or off of transit. Entering and leaving transit is

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
@@ -136,7 +136,7 @@ public class TransitBoardAlight extends TablePatternEdge implements OnboardEdge 
         }
 
         for (AlertPatch alertPatch: options.getRoutingContext().graph.getAlertPatches(this)) {
-            if (alertPatch.cannotAlightOrBoard() && alertPatch.displayDuring(s0)) {
+            if ((alertPatch.cannotBoard() || alertPatch.cannotAlight()) && alertPatch.displayDuring(s0)) {
                 return null;
             }
         }

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -394,6 +394,21 @@ public class Graph implements Serializable {
         return new AlertPatch[0];
     }
 
+
+    /**
+     * Get {@link AlertPatch} {@link Set} for the graph.
+     * @return The {@link AlertPatch} set for the graph
+     */
+    public Set<AlertPatch> getAlertPatches() {
+        Set<AlertPatch> result = new HashSet<>();
+
+        synchronized (alertPatches) {
+            this.alertPatches.values().forEach(result::addAll);
+        }
+
+        return result;
+    }
+
     /**
      * Add a {@link TurnRestriction} to the {@link TurnRestriction} {@link List} belonging to an
      * {@link Edge}. This method is not thread-safe.

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -396,17 +396,17 @@ public class Graph implements Serializable {
 
 
     /**
-     * Get {@link AlertPatch} {@link Set} for the graph.
-     * @return The {@link AlertPatch} set for the graph
+     * Get {@link AlertPatch} array for the graph.
+     * @return The {@link AlertPatch} array for the graph
      */
-    public Set<AlertPatch> getAlertPatches() {
+    public AlertPatch[] getAllAlertPatches() {
         Set<AlertPatch> result = new HashSet<>();
 
         synchronized (alertPatches) {
             this.alertPatches.values().forEach(result::addAll);
         }
 
-        return result;
+        return result.toArray(new AlertPatch[0]);
     }
 
     /**

--- a/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java
+++ b/src/main/java/org/opentripplanner/updater/GraphUpdaterConfigurator.java
@@ -2,6 +2,7 @@ package org.opentripplanner.updater;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.updater.alerts.GtfsEnhancedRealtimeAlertsUpdater;
 import org.opentripplanner.updater.alerts.GtfsRealtimeAlertsUpdater;
 import org.opentripplanner.updater.bike_park.BikeParkUpdater;
 import org.opentripplanner.updater.bike_rental.BikeRentalUpdater;
@@ -81,6 +82,9 @@ public abstract class GraphUpdaterConfigurator {
                 }
                 else if (type.equals("real-time-alerts")) {
                     updater = new GtfsRealtimeAlertsUpdater();
+                }
+                else if (type.equals("real-time-alerts-enhanced")) {
+                    updater = new GtfsEnhancedRealtimeAlertsUpdater();
                 }
                 else if (type.equals("example-updater")) {
                     updater = new ExampleGraphUpdater();

--- a/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
@@ -59,6 +59,7 @@ public class AlertsUpdateHandler {
         alertText.alertDescriptionText = deBuffer(alert.getDescriptionText());
         alertText.alertHeaderText = deBuffer(alert.getHeaderText());
         alertText.alertUrl = deBuffer(alert.getUrl());
+        alertText.setId(id);
         ArrayList<TimePeriod> periods = new ArrayList<TimePeriod>();
         if(alert.getActivePeriodCount() > 0) {
             long bestStartTime = Long.MAX_VALUE;

--- a/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/AlertsUpdateHandler.java
@@ -60,6 +60,7 @@ public class AlertsUpdateHandler {
         alertText.alertHeaderText = deBuffer(alert.getHeaderText());
         alertText.alertUrl = deBuffer(alert.getUrl());
         alertText.setId(id);
+        alertText.setEffect(alert.getEffect());
         ArrayList<TimePeriod> periods = new ArrayList<TimePeriod>();
         if(alert.getActivePeriodCount() > 0) {
             long bestStartTime = Long.MAX_VALUE;

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
@@ -112,7 +112,7 @@ public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
     }
 
     private void updateGraph(Graph graph) {
-        for (AlertPatch alertPatch: graph.getAlertPatches()) {
+        for (AlertPatch alertPatch: graph.getAllAlertPatches()) {
             List<EnhancedAlert> newAlerts = new ArrayList<>();
 
             List<EnhancedAlert> enhancedAlerts = alertDetails.get(alertPatch.getAlert().getId());

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
@@ -1,0 +1,83 @@
+package org.opentripplanner.updater.alerts;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.opentripplanner.routing.alertpatch.AlertPatch;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.updater.GraphUpdaterManager;
+import org.opentripplanner.updater.PollingGraphUpdater;
+import org.opentripplanner.util.HttpUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
+    private static final Logger LOG = LoggerFactory.getLogger(GtfsRealtimeAlertsUpdater.class);
+
+    private GraphUpdaterManager updaterManager;
+
+    private String url;
+
+    private Map<String, String> alertEffectDetails;
+
+    @Override
+    protected void runPolling() {
+        try {
+            InputStream data = HttpUtils.getData(url);
+            if (data == null) {
+                throw new RuntimeException("Failed to get data from url " + url);
+            }
+
+            alertEffectDetails = parseJson(IOUtils.toString(data));
+            updaterManager.execute(this::updateGraph);
+        } catch (Exception e) {
+            LOG.error("Error reading enhanced feed from " + url, e);
+        }
+    }
+
+    @Override
+    protected void configurePolling(Graph graph, JsonNode config) {
+        String url = config.path("url").asText();
+        if (url == null) {
+            throw new IllegalArgumentException("Missing mandatory 'url' parameter");
+        }
+        this.url = url;
+        LOG.info("Creating enhanced alert feed updater running every {} seconds: {}", pollingPeriodSeconds, url);
+    }
+
+    @Override
+    public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
+        this.updaterManager = updaterManager;
+    }
+
+    @Override
+    public void setup(Graph graph) {}
+
+    @Override
+    public void teardown() {}
+
+    private Map<String, String> parseJson(String jsonString) throws Exception {
+        Map<String, String> result = new HashMap<>();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode json = mapper.readTree(jsonString);
+
+        for (JsonNode node: json.get("entity")) {
+            result.put(node.get("id").textValue(), node.get("alert").get("effect_detail").textValue());
+        }
+
+        return result;
+    }
+
+    private void updateGraph(Graph graph)
+    {
+        for (AlertPatch alertPatch: graph.getAlertPatches()) {
+            String effectDetails = alertEffectDetails.get(alertPatch.getAlert().getId());
+            alertPatch.getAlert().setEffectDetails(effectDetails);
+        }
+    }
+}

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
@@ -3,6 +3,8 @@ package org.opentripplanner.updater.alerts;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
+import org.opentripplanner.model.FeedScopedId;
+import org.opentripplanner.model.EnhancedAlert;
 import org.opentripplanner.routing.alertpatch.AlertPatch;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.updater.GraphUpdaterManager;
@@ -12,17 +14,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
-    private static final Logger LOG = LoggerFactory.getLogger(GtfsRealtimeAlertsUpdater.class);
+    private static final Logger LOG = LoggerFactory.getLogger(GtfsEnhancedRealtimeAlertsUpdater.class);
 
     private GraphUpdaterManager updaterManager;
 
     private String url;
 
-    private Map<String, String> alertEffectDetails;
+    private Map<String, List<EnhancedAlert>> alertDetails;
+
+    private final String AGENCY_ID = "1";
 
     @Override
     protected void runPolling() {
@@ -32,7 +38,7 @@ public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
                 throw new RuntimeException("Failed to get data from url " + url);
             }
 
-            alertEffectDetails = parseJson(IOUtils.toString(data));
+            alertDetails = parseJson(IOUtils.toString(data));
             updaterManager.execute(this::updateGraph);
         } catch (Exception e) {
             LOG.error("Error reading enhanced feed from " + url, e);
@@ -60,24 +66,63 @@ public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
     @Override
     public void teardown() {}
 
-    private Map<String, String> parseJson(String jsonString) throws Exception {
-        Map<String, String> result = new HashMap<>();
+    public String toString() {
+        return "GtfsEnhancedRealtimeAlertsUpdater(" + url + ")";
+    }
+
+    private Map<String, List<EnhancedAlert>> parseJson(String jsonString) throws Exception {
+        Map<String, List<EnhancedAlert>> result = new HashMap<>();
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode json = mapper.readTree(jsonString);
 
         for (JsonNode node: json.get("entity")) {
-            result.put(node.get("id").textValue(), node.get("alert").get("effect_detail").textValue());
+            String id = node.get("id").textValue();
+
+            List<EnhancedAlert> enhancedAlerts = new ArrayList<>();
+
+            for (JsonNode ie: node.get("alert").get("informed_entity")) {
+                EnhancedAlert alert = new EnhancedAlert();
+
+                if (ie.hasNonNull("route_id")) {
+                    alert.setRoute(new FeedScopedId(AGENCY_ID, ie.get("route_id").textValue()));
+                }
+                if (ie.hasNonNull("stop_id")) {
+                    alert.setStop(new FeedScopedId(AGENCY_ID, ie.get("stop_id").textValue()));
+                }
+                if (ie.hasNonNull("trip") && ie.get("trip").hasNonNull("trip_id")) {
+                    alert.setTrip(new FeedScopedId(AGENCY_ID, ie.get("trip").get("trip_id").textValue()));
+                }
+
+                List<EnhancedAlert.AffectedActivity> activities = new ArrayList<>();
+
+                for (JsonNode activity: ie.get("activities")) {
+                    activities.add(EnhancedAlert.AffectedActivity.valueOf(activity.textValue()));
+                }
+
+                alert.setActivities(activities);
+
+                enhancedAlerts.add(alert);
+            }
+
+            result.put(id, enhancedAlerts);
         }
 
         return result;
     }
 
-    private void updateGraph(Graph graph)
-    {
+    private void updateGraph(Graph graph) {
         for (AlertPatch alertPatch: graph.getAlertPatches()) {
-            String effectDetails = alertEffectDetails.get(alertPatch.getAlert().getId());
-            alertPatch.getAlert().setEffectDetails(effectDetails);
+            List<EnhancedAlert> newAlerts = new ArrayList<>();
+
+            List<EnhancedAlert> enhancedAlerts = alertDetails.get(alertPatch.getAlert().getId());
+            for (EnhancedAlert alert: enhancedAlerts) {
+                if (alert.appliesTo(alertPatch)) {
+                    newAlerts.add(alert);
+                }
+            }
+
+            alertPatch.setEnhancedAlerts(newAlerts);
         }
     }
 }


### PR DESCRIPTION
Ticket: [Rider doesn't see closed stations or other impossible trips due to major disruption](https://app.asana.com/0/810933294009540/376328591999976)

In the end I decided to use the enhanced feed only to enrich existing alerts coming from protobuf feed. Otherwise, I'd end up writing tons of code, which would effectively duplicate existing pb processing. 

Once this PR is merged, we would need to make corresponding change to `router-config.json` in https://github.com/mbta/otp-deploy/.

**Examples**:

**With Chinatown station closed (but no service suspended)**:
1) Doesn't allow to enter there:
![image](https://user-images.githubusercontent.com/45011335/52373725-618a7380-2a29-11e9-925a-7e3e7923df0c.png)
2) Doesn't allow to exit there:
![image](https://user-images.githubusercontent.com/45011335/52373763-7e26ab80-2a29-11e9-8a79-cfd4b55ae67a.png)
3) Does allow to ride through:
![image](https://user-images.githubusercontent.com/45011335/52373798-9991b680-2a29-11e9-8900-07b634728ffe.png)
4) Does allow to enter/exit on the next day (when alert is not active):
![image](https://user-images.githubusercontent.com/45011335/52373838-b4fcc180-2a29-11e9-8378-dcd90f18447b.png)

**With Red Line service suspension on Andrew and JFK/UMass**:
1) Doesn't allow to ride through:
![image](https://user-images.githubusercontent.com/45011335/52373944-00af6b00-2a2a-11e9-870b-fa76f92edd17.png)
2) Doesn't allow to enter/exit:
![image](https://user-images.githubusercontent.com/45011335/52374000-23da1a80-2a2a-11e9-8a77-c4271a6f91b4.png)
3) Does allow to ride/enter/exit on the next day (when alert is not active):
![image](https://user-images.githubusercontent.com/45011335/52374052-41a77f80-2a2a-11e9-96c0-20831b7d6fc0.png)
