### PR TITLE
Refactor nearby stops search

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java
@@ -84,11 +84,15 @@ public class DirectTransferGenerator implements GraphBuilderModule {
                 }
             }
 
-            /* Make transfers to each nearby stop that is the closest stop on some trip pattern. */
+            /* Make transfers to each nearby stop. */
             int n = 0;
-            for (NearbyStopFinder.StopAtDistance sd : nearbyStopFinder.findNearbyStopsConsideringPatterns(ts0)) {
+            for (NearbyStopFinder.StopAtDistance sd : nearbyStopFinder.findNearbyStops(ts0)) {
                 /* Skip the origin stop, loop transfers are not needed. */
                 if (sd.tstop == ts0 || pathwayDestinations.contains(sd.tstop)) continue;
+
+                /* Skip stops, which are not street linkable */
+                if (!sd.tstop.isStreetLinkable()) continue;
+
                 /* Don't link stops, which have already been linked through GTFS, unless they are from different agencies */
                 if ((sd.tstop.hasGtfsTransfers() || ts0.hasGtfsTransfers()) &&
                         sd.tstop.getStopId().getAgencyId().equals(ts0.getStopId().getAgencyId()))

--- a/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/NearbyStopFinder.java
@@ -80,34 +80,21 @@ public class NearbyStopFinder {
     }
 
     /**
-     * Find all unique nearby stops that are the closest stop on some trip pattern.
+     * Find all unique nearby stops
      * Note that the result will include the origin vertex if it is an instance of TransitStop.
      * This is intentional: we don't want to return the next stop down the line for trip patterns that pass through the
      * origin vertex.
      */
     public Set<StopAtDistance> findNearbyStopsConsideringPatterns (Vertex vertex) {
-
-        /* Track the closest stop on each pattern passing nearby. */
-        SimpleIsochrone.MinMap<TripPattern, StopAtDistance> closestStopForPattern =
-                new SimpleIsochrone.MinMap<TripPattern, StopAtDistance>();
+        Set<StopAtDistance> uniqueStops = Sets.newHashSet();
 
         /* Iterate over nearby stops via the street network or using straight-line distance, depending on the graph. */
         for (NearbyStopFinder.StopAtDistance stopAtDistance : findNearbyStops(vertex)) {
-            /* Filter out destination stops that are already reachable via pathways or transfers. */
-            // FIXME why is the above comment relevant here? how does the next line achieve this?
-            TransitStop ts1 = stopAtDistance.tstop;
-            if (!ts1.isStreetLinkable()) continue;
-            /* Consider this destination stop as a candidate for every trip pattern passing through it. */
-            for (TripPattern pattern : graph.index.patternsForStop.get(ts1.getStop())) {
-                closestStopForPattern.putMin(pattern, stopAtDistance);
+            if (stopAtDistance.tstop.isStreetLinkable()) {
+                uniqueStops.add(stopAtDistance);
             }
         }
-
-        /* Make a transfer from the origin stop to each destination stop that was the closest stop on any pattern. */
-        Set<StopAtDistance> uniqueStops = Sets.newHashSet();
-        uniqueStops.addAll(closestStopForPattern.values());
         return uniqueStops;
-
     }
 
 


### PR DESCRIPTION
Ticket: [Trip Planner doesn't suggest to use airport shuttles when appropriate](https://app.asana.com/0/810933294009540/1109557837333471)

I don't really understand why they had implemented nearby search algorithm like this, i.e. what stops being near one to another has to do with trip patterns (we don't really care about trips, we just want to make the possible transfer between the stops if they are near), so I had to simplify it. We just add transfers between that stops if they are near, that's it. 

Before:
![image](https://user-images.githubusercontent.com/45011335/53189386-6167a780-35d5-11e9-9769-7189bffd1b81.png)

After:
![image](https://user-images.githubusercontent.com/45011335/53189411-717f8700-35d5-11e9-97b5-0a09f455ea23.png)

I did additional smoke testing on random trips (especially long bus trips with multiple connections) and found no issues so far. 