### PR TITLE
Sort input GTFS files while building

### DIFF
--- a/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
+++ b/src/main/java/org/opentripplanner/graph_builder/GraphBuilder.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.zip.ZipEntry;
@@ -183,7 +184,10 @@ public class GraphBuilder implements Runnable {
         routerConfig = OTPMain.loadJson(new File(dir, Router.ROUTER_CONFIG_FILENAME));
         LOG.info(ReflectionLibrary.dumpFields(builderParams));
 
-        for (File file : dir.listFiles()) {
+        File[] files = dir.listFiles();
+        Arrays.sort(files);
+
+        for (File file : files) {
             switch (InputFileType.forFile(file)) {
                 case GTFS:
                     LOG.info("Found GTFS file {}", file);

--- a/src/main/java/org/opentripplanner/routing/edgetype/PatternHop.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PatternHop.java
@@ -14,15 +14,12 @@ import org.opentripplanner.routing.trippattern.TripTimes;
 import org.opentripplanner.routing.vertextype.PatternStopVertex;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.LineString;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A transit vehicle's journey between departure at one stop and arrival at the next.
  * This version represents a set of such journeys specified by a TripPattern.
  */
 public class PatternHop extends TablePatternEdge implements OnboardEdge, HopEdge {
-    private static final Logger LOG = LoggerFactory.getLogger(PatternHop.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -71,7 +68,6 @@ public class PatternHop extends TablePatternEdge implements OnboardEdge, HopEdge
 
         for (AlertPatch alertPatch: options.getRoutingContext().graph.getAlertPatches(this)) {
             if (alertPatch.cannotRideThrough() && alertPatch.displayDuring(state0)) {
-                LOG.warn("Trip affected by alert " + alertPatch.getId() + ": " + alertPatch.getAlert().toString());
                 return null;
             }
         }
@@ -107,7 +103,6 @@ public class PatternHop extends TablePatternEdge implements OnboardEdge, HopEdge
 
         for (AlertPatch alertPatch: options.getRoutingContext().graph.getAlertPatches(this)) {
             if (alertPatch.cannotRideThrough() && alertPatch.displayDuring(s0)) {
-                LOG.warn("Trip affected by alert " + alertPatch.getId() + ": " + alertPatch.getAlert().toString());
                 return null;
             }
         }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
@@ -137,7 +137,6 @@ public class TransitBoardAlight extends TablePatternEdge implements OnboardEdge 
 
         for (AlertPatch alertPatch: options.getRoutingContext().graph.getAlertPatches(this)) {
             if ((alertPatch.cannotBoard() || alertPatch.cannotAlight()) && alertPatch.displayDuring(s0)) {
-                LOG.warn("Trip affected by alert " + alertPatch.getId() + ": " + alertPatch.getAlert().toString());
                 return null;
             }
         }

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
@@ -83,10 +83,7 @@ public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
                 throw new RuntimeException("Failed to get json data from url " + url);
             }
 
-            String stringData = IOUtils.toString(data);
-            LOG.info("Read enhanced json stream from " + url + " : " + stringData);
-
-            final FeedMessage feed = parseJson(stringData);
+            final FeedMessage feed = parseJson(IOUtils.toString(data));
 
             long feedTimestamp = feed.getHeader().getTimestamp();
             if (feedTimestamp <= lastTimestamp) {
@@ -101,8 +98,6 @@ public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
                     updateHandler.update(feed);
                 }
             });
-
-            LOG.info(feed.getEntityCount() + " alerts parsed");
 
             lastTimestamp = feedTimestamp;
         } catch (Exception e) {


### PR DESCRIPTION
Ticket: [Trip planner suggests the route affected by disruption](https://app.asana.com/0/810933294009540/1115762511783454)

Apparently trip planner assigns whatever agency id it finds in _the first_ GTFS file it parses as the default agency ID ([ref](https://github.com/mbta/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/gtfs/GtfsImport.java#L39)), which is later used to match the alerts. 

So when I was running the build locally, it used to parse MBTA's GTFS first:
```bash
13:13:21.887 INFO (GraphBuilder.java:193) Found OSM file var/graphs/mbta/rhode-island-latest.osm.pbf
13:13:21.887 INFO (GraphBuilder.java:193) Found OSM file var/graphs/mbta/massachusetts-latest.osm.pbf
13:13:21.889 INFO (GraphBuilder.java:189) Found GTFS file var/graphs/mbta/MBTA_GTFS.zip
13:13:21.889 INFO (GraphBuilder.java:189) Found GTFS file var/graphs/mbta/loganexpress-ma-us.zip
```

Whereas the hosted version for some reason parses Massport's GTFS first ([ref](https://semaphoreci.com/mbta/otp-deploy/servers/otp-dev/deploys/306)):
```bash
17:02:50.524 INFO (GraphBuilder.java:189) Found GTFS file var/graphs/mbta/loganexpress-ma-us.zip
17:02:50.525 INFO (GraphBuilder.java:189) Found GTFS file var/graphs/mbta/MBTA_GTFS.zip
17:02:50.526 INFO (GraphBuilder.java:193) Found OSM file var/graphs/mbta/rhode-island-latest.osm.pbf
17:02:50.526 INFO (GraphBuilder.java:193) Found OSM file var/graphs/mbta/massachusetts-latest.osm.pbf
```

This PR sorts input file alphabetically to mitigate this and also reverts previously added logging (as those logs are huge). 

Tested it on dev, and it solves the problem (note that it doesn't offer to take Bus 86): 
![image](https://user-images.githubusercontent.com/45011335/55903265-422fd400-5b9b-11e9-938c-6850827eff74.png)
