### PR TITLE
 Support for MBTA's GTFS pathways 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -668,7 +668,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>1.3.64-MBTA</version>
+            <version>1.3.66-MBTA</version>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>

--- a/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
+++ b/src/main/java/org/opentripplanner/graph_builder/linking/SimpleStreetSplitter.java
@@ -429,7 +429,7 @@ public class SimpleStreetSplitter {
     private void makeLinkEdges(Vertex from, StreetVertex to) {
         if (from instanceof TemporaryStreetLocation) {
             makeTemporaryEdges((TemporaryStreetLocation) from, to);
-        } else if (from instanceof TransitStop) {
+        } else if (from instanceof TransitStop && ((TransitStop) from).isStreetLinkable()) {
             makeTransitLinkEdges((TransitStop) from, to);
         } else if (from instanceof BikeRentalStationVertex) {
             makeBikeRentalLinkEdges((BikeRentalStationVertex) from, to);

--- a/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
+++ b/src/main/java/org/opentripplanner/graph_builder/module/GtfsModule.java
@@ -14,16 +14,7 @@ import java.util.Set;
 
 import org.onebusaway.csv_entities.EntityHandler;
 import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
-import org.onebusaway.gtfs.model.Agency;
-import org.onebusaway.gtfs.model.FareAttribute;
-import org.onebusaway.gtfs.model.IdentityBean;
-import org.onebusaway.gtfs.model.Pathway;
-import org.onebusaway.gtfs.model.Route;
-import org.onebusaway.gtfs.model.ServiceCalendar;
-import org.onebusaway.gtfs.model.ServiceCalendarDate;
-import org.onebusaway.gtfs.model.ShapePoint;
-import org.onebusaway.gtfs.model.Stop;
-import org.onebusaway.gtfs.model.Trip;
+import org.onebusaway.gtfs.model.*;
 import org.onebusaway.gtfs.serialization.GtfsReader;
 import org.onebusaway.gtfs.services.GenericMutableDao;
 import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
@@ -215,6 +206,15 @@ public class GtfsModule implements GraphBuilderModule {
         }
         for (Stop stop : store.getAllEntitiesForType(Stop.class)) {
             stop.getId().setAgencyId(reader.getDefaultAgencyId());
+        }
+        for (Stop stop : store.getAllEntitiesForType(Stop.class)) {
+            if (stop.getLat() == Stop.MISSING_VALUE && stop.getLon() == Stop.MISSING_VALUE) {
+                // if certain stop doesn't have coordinates, we use parent stop's coordinates
+                AgencyAndId key = new AgencyAndId(reader.getDefaultAgencyId(), stop.getParentStation());
+                Stop parent = store.getEntityForId(Stop.class, key);
+                stop.setLat(parent.getLat());
+                stop.setLon(parent.getLon());
+            }
         }
         for (Trip trip : store.getAllEntitiesForType(Trip.class)) {
             trip.getId().setAgencyId(reader.getDefaultAgencyId());

--- a/src/main/java/org/opentripplanner/gtfs/mapping/PathwayMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/PathwayMapper.java
@@ -31,11 +31,14 @@ class PathwayMapper {
         Pathway lhs = new Pathway();
 
         lhs.setId(AgencyAndIdMapper.mapAgencyAndId(rhs.getId()));
-        lhs.setPathwayType(rhs.getPathwayType());
+        lhs.setPathwayMode(rhs.getPathwayMode());
         lhs.setFromStop(stopMapper.map(rhs.getFromStop()));
         lhs.setToStop(stopMapper.map(rhs.getToStop()));
         lhs.setTraversalTime(rhs.getTraversalTime());
         lhs.setWheelchairTraversalTime(rhs.getWheelchairTraversalTime());
+        lhs.setLength(rhs.getLength());
+        lhs.setWheelchairLength(rhs.getWheelchairLength());
+        lhs.setStairCount(rhs.getStairCount());
 
         return lhs;
     }

--- a/src/main/java/org/opentripplanner/gtfs/mapping/PathwayMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/PathwayMapper.java
@@ -39,6 +39,7 @@ class PathwayMapper {
         lhs.setLength(rhs.getLength());
         lhs.setWheelchairLength(rhs.getWheelchairLength());
         lhs.setStairCount(rhs.getStairCount());
+        lhs.setSignpostedAs(rhs.getSignpostedAs());
 
         return lhs;
     }

--- a/src/main/java/org/opentripplanner/model/Pathway.java
+++ b/src/main/java/org/opentripplanner/model/Pathway.java
@@ -78,10 +78,11 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
     }
 
     public int calculateTraversalTime() {
+        if (pathwayMode == 5) return MISSING_VALUE; // offer elevators for accessible trips only
         if (traversalTime != MISSING_VALUE) return traversalTime;
-        else if (stairCount != MISSING_VALUE) return (int)(stairCount / (stairCount > 0 ? STAIRS_UP_SPEED : STAIRS_DOWN_SPEED));
-        else if (length > 0) return (int)(length / WALK_SPEED_FEET_SECONDS);
-        else return DEFAULT_TRAVERSAL_TIME;
+        if (stairCount != MISSING_VALUE) return (int)(Math.abs(stairCount) / (stairCount > 0 ? STAIRS_UP_SPEED : STAIRS_DOWN_SPEED));
+        if (length > 0) return (int)(length / WALK_SPEED_FEET_SECONDS);
+        return DEFAULT_TRAVERSAL_TIME;
     }
 
     public void setWheelchairTraversalTime(int wheelchairTraversalTime) {
@@ -90,8 +91,8 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
 
     public int calculateWheelchairTraversalTime() {
         if (wheelchairTraversalTime != MISSING_VALUE) return wheelchairTraversalTime;
-        else if (wheelchairLength > 0) return (int)(wheelchairLength / WHEELCHAIR_SPEED_FEET_SECONDS);
-        else return DEFAULT_WHEELCHAIR_TRAVERSAL_TIME;
+        if (wheelchairLength > 0) return (int)(wheelchairLength / WHEELCHAIR_SPEED_FEET_SECONDS);
+        return DEFAULT_WHEELCHAIR_TRAVERSAL_TIME;
     }
 
     public float getLength() {

--- a/src/main/java/org/opentripplanner/model/Pathway.java
+++ b/src/main/java/org/opentripplanner/model/Pathway.java
@@ -7,6 +7,10 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
 
     private static final int MISSING_VALUE = -999;
 
+    private static final int DEFAULT_TRAVERSAL_TIME = 5;
+
+    private static final int DEFAULT_WHEELCHAIR_TRAVERSAL_TIME = 10;
+
     private static final float WALK_SPEED_FEET_SECONDS = 4.59f;
 
     private static final float WHEELCHAIR_SPEED_FEET_SECONDS = 3.5481f;
@@ -77,7 +81,7 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
         if (traversalTime != MISSING_VALUE) return traversalTime;
         else if (stairCount != MISSING_VALUE) return (int)(stairCount / (stairCount > 0 ? STAIRS_UP_SPEED : STAIRS_DOWN_SPEED));
         else if (length > 0) return (int)(length / WALK_SPEED_FEET_SECONDS);
-        else return MISSING_VALUE;
+        else return DEFAULT_TRAVERSAL_TIME;
     }
 
     public void setWheelchairTraversalTime(int wheelchairTraversalTime) {
@@ -87,7 +91,7 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
     public int calculateWheelchairTraversalTime() {
         if (wheelchairTraversalTime != MISSING_VALUE) return wheelchairTraversalTime;
         else if (wheelchairLength > 0) return (int)(wheelchairLength / WHEELCHAIR_SPEED_FEET_SECONDS);
-        else return MISSING_VALUE;
+        else return DEFAULT_WHEELCHAIR_TRAVERSAL_TIME;
     }
 
     public float getLength() {

--- a/src/main/java/org/opentripplanner/model/Pathway.java
+++ b/src/main/java/org/opentripplanner/model/Pathway.java
@@ -33,6 +33,8 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
 
     private int stairCount = MISSING_VALUE;
 
+    private String signpostedAs;
+
     @Override
     public FeedScopedId getId() {
         return id;
@@ -118,6 +120,14 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
 
     public void clearWheelchairTraversalTime() {
         this.wheelchairTraversalTime = MISSING_VALUE;
+    }
+
+    public String getSignpostedAs() {
+        return signpostedAs;
+    }
+
+    public void setSignpostedAs(String signpostedAs) {
+        this.signpostedAs = signpostedAs;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/model/Pathway.java
+++ b/src/main/java/org/opentripplanner/model/Pathway.java
@@ -11,9 +11,9 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
 
     private static final int DEFAULT_WHEELCHAIR_TRAVERSAL_TIME = 10;
 
-    private static final float WALK_SPEED_FEET_SECONDS = 4.59f;
+    private static final float WALK_SPEED_METERS_PER_SECONDS = 1.4f;
 
-    private static final float WHEELCHAIR_SPEED_FEET_SECONDS = 3.5481f;
+    private static final float WHEELCHAIR_SPEED_METERS_PER_SECONDS = 1.08f;
 
     private static final float STAIRS_UP_SPEED = 1.6404f;
 
@@ -81,7 +81,7 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
         if (pathwayMode == 5) return MISSING_VALUE; // offer elevators for accessible trips only
         if (traversalTime != MISSING_VALUE) return traversalTime;
         if (stairCount != MISSING_VALUE) return (int)(Math.abs(stairCount) / (stairCount > 0 ? STAIRS_UP_SPEED : STAIRS_DOWN_SPEED));
-        if (length > 0) return (int)(length / WALK_SPEED_FEET_SECONDS);
+        if (length > 0) return (int)(length / WALK_SPEED_METERS_PER_SECONDS);
         return DEFAULT_TRAVERSAL_TIME;
     }
 
@@ -91,8 +91,9 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
 
     public int calculateWheelchairTraversalTime() {
         if (wheelchairTraversalTime != MISSING_VALUE) return wheelchairTraversalTime;
-        if (wheelchairLength > 0) return (int)(wheelchairLength / WHEELCHAIR_SPEED_FEET_SECONDS);
-        return DEFAULT_WHEELCHAIR_TRAVERSAL_TIME;
+        if (wheelchairLength > 0) return (int)(wheelchairLength / WHEELCHAIR_SPEED_METERS_PER_SECONDS);
+        if (pathwayMode == 6 || pathwayMode == 7) return DEFAULT_WHEELCHAIR_TRAVERSAL_TIME; // entering/exiting fare control
+        return MISSING_VALUE; // consider pathway to be inaccessible if we don't know for sure that it's accessible
     }
 
     public float getLength() {

--- a/src/main/java/org/opentripplanner/model/Pathway.java
+++ b/src/main/java/org/opentripplanner/model/Pathway.java
@@ -116,19 +116,9 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
         return wheelchairTraversalTime != MISSING_VALUE;
     }
 
-    public boolean isTraversalTimeSet() {
-        return traversalTime != MISSING_VALUE;
-    }
-
     public void clearWheelchairTraversalTime() {
         this.wheelchairTraversalTime = MISSING_VALUE;
     }
-
-    public boolean isAccessible() {
-        if (stairCount == MISSING_VALUE) return wheelchairTraversalTime > 0;
-        else return stairCount == 0;
-    }
-
 
     @Override
     public String toString() {

--- a/src/main/java/org/opentripplanner/model/Pathway.java
+++ b/src/main/java/org/opentripplanner/model/Pathway.java
@@ -7,9 +7,17 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
 
     private static final int MISSING_VALUE = -999;
 
+    private static final float WALK_SPEED_FEET_SECONDS = 4.59f;
+
+    private static final float WHEELCHAIR_SPEED_FEET_SECONDS = 3.5481f;
+
+    private static final float STAIRS_UP_SPEED = 1.6404f;
+
+    private static final float STAIRS_DOWN_SPEED = 2.0013f;
+
     private FeedScopedId id;
 
-    private int pathwayType;
+    private int pathwayMode;
 
     private Stop fromStop;
 
@@ -18,6 +26,12 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
     private int traversalTime;
 
     private int wheelchairTraversalTime = MISSING_VALUE;
+
+    private float length = MISSING_VALUE;
+
+    private float wheelchairLength = MISSING_VALUE;
+
+    private int stairCount = MISSING_VALUE;
 
     @Override
     public FeedScopedId getId() {
@@ -29,12 +43,12 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
         this.id = id;
     }
 
-    public void setPathwayType(int pathwayType) {
-        this.pathwayType = pathwayType;
+    public void setPathwayMode(int pathwayMode) {
+        this.pathwayMode = pathwayMode;
     }
 
-    public int getPathwayType() {
-        return pathwayType;
+    public int getPathwayMode() {
+        return pathwayMode;
     }
 
     public void setFromStop(Stop fromStop) {
@@ -57,25 +71,64 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
         this.traversalTime = traversalTime;
     }
 
-    public int getTraversalTime() {
-        return traversalTime;
+    public int calculateTraversalTime() {
+        if (traversalTime != MISSING_VALUE) return traversalTime;
+        else if (stairCount != MISSING_VALUE) return (int)(stairCount / (stairCount > 0 ? STAIRS_UP_SPEED : STAIRS_DOWN_SPEED));
+        else if (length > 0) return (int)(length / WALK_SPEED_FEET_SECONDS);
+        else return MISSING_VALUE;
     }
 
     public void setWheelchairTraversalTime(int wheelchairTraversalTime) {
         this.wheelchairTraversalTime = wheelchairTraversalTime;
     }
 
-    public int getWheelchairTraversalTime() {
-        return wheelchairTraversalTime;
+    public int calculateWheelchairTraversalTime() {
+        if (wheelchairTraversalTime != MISSING_VALUE) return wheelchairTraversalTime;
+        else if (wheelchairLength > 0) return (int)(wheelchairLength / WHEELCHAIR_SPEED_FEET_SECONDS);
+        else return MISSING_VALUE;
+    }
+
+    public float getLength() {
+        return length;
+    }
+
+    public void setLength(float length) {
+        this.length = length;
+    }
+
+    public float getWheelchairLength() {
+        return wheelchairLength;
+    }
+
+    public void setWheelchairLength(float wheelchairLength) {
+        this.wheelchairLength = wheelchairLength;
+    }
+
+    public int getStairCount() {
+        return stairCount;
+    }
+
+    public void setStairCount(int stairCount) {
+        this.stairCount = stairCount;
     }
 
     public boolean isWheelchairTraversalTimeSet() {
         return wheelchairTraversalTime != MISSING_VALUE;
     }
 
+    public boolean isTraversalTimeSet() {
+        return traversalTime != MISSING_VALUE;
+    }
+
     public void clearWheelchairTraversalTime() {
         this.wheelchairTraversalTime = MISSING_VALUE;
     }
+
+    public boolean isAccessible() {
+        if (stairCount == MISSING_VALUE) return wheelchairTraversalTime > 0;
+        else return stairCount == 0;
+    }
+
 
     @Override
     public String toString() {

--- a/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
@@ -22,6 +22,8 @@ public class PathwayEdge extends Edge {
 
     private double distance = -1;
 
+    private String name;
+
     public PathwayEdge(Vertex fromv, Vertex tov) {
         super(fromv, tov);
     }
@@ -58,8 +60,12 @@ public class PathwayEdge extends Edge {
         return GeometryUtils.getGeometryFactory().createLineString(coordinates);
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public String getName() {
-        return "pathway";
+        return name;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
@@ -96,4 +96,9 @@ public class PathwayEdge extends Edge {
         s1.setBackMode(getMode());
         return s1.makeState();
     }
+
+    public String toString() {
+        return "PathwayEdge(" + getId() + ", " + name + ", " + fromv + " -> " + tov
+                + " length=" + this.getDistance() + ")";
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PathwayEdge.java
@@ -16,19 +16,22 @@ import java.util.Locale;
  */
 public class PathwayEdge extends Edge {
 
-    private int traversalTime;
+    private int traversalTime = -1;
 
     private int wheelchairTraversalTime = -1;
 
-    public PathwayEdge(Vertex fromv, Vertex tov, int traversalTime, int wheelchairTraversalTime) {
+    private double distance = -1;
+
+    public PathwayEdge(Vertex fromv, Vertex tov) {
         super(fromv, tov);
-        this.traversalTime = traversalTime;
-        this.wheelchairTraversalTime = wheelchairTraversalTime;
     }
 
-    public PathwayEdge(Vertex fromv, Vertex tov, int traversalTime) {
-        super(fromv, tov);
+    public void setTraversalTime(int traversalTime) {
         this.traversalTime = traversalTime;
+    }
+
+    public void setWheelchairTraversalTime(int wheelchairTraversalTime) {
+        this.wheelchairTraversalTime = wheelchairTraversalTime;
     }
 
     private static final long serialVersionUID = -3311099256178798981L;
@@ -38,9 +41,13 @@ public class PathwayEdge extends Edge {
     }
 
     public double getDistance() {
-        return 0;
+        return distance;
     }
-    
+
+    public void setDistance(double distance) {
+        this.distance = distance;
+    }
+
     public TraverseMode getMode() {
        return TraverseMode.WALK;
     }
@@ -62,12 +69,20 @@ public class PathwayEdge extends Edge {
     }
 
     public State traverse(State s0) {
-        int time = traversalTime;
+        int time;
         if (s0.getOptions().wheelchairAccessible) {
             if (wheelchairTraversalTime < 0) {
                 return null;
             }
             time = wheelchairTraversalTime;
+        }
+        else
+        {
+            // some pathways (e.g. elevators) only have accessible traversal time known
+            if (traversalTime < 0) {
+                return null;
+            }
+            time = traversalTime;
         }
         StateEditor s1 = s0.edit(this);
         s1.incrementTimeInSeconds(time);

--- a/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/StreetEdge.java
@@ -184,7 +184,7 @@ public class StreetEdge extends Edge implements Cloneable {
      * @return
      */
     private boolean canTraverse(RoutingRequest options, TraverseMode mode) {
-        if (options.wheelchairAccessible) {
+        if (!options.modes.isTransit() && options.wheelchairAccessible) {
             if (!isWheelchairAccessible()) {
                 return false;
             }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransferEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransferEdge.java
@@ -96,4 +96,8 @@ public class TransferEdge extends Edge {
         return wheelchairAccessible;
     }
 
+    public String toString() {
+        return "TransferEdge(" + getId() + ", " + fromv + " -> " + tov
+                + " length=" + this.getDistance() + ")";
+    }
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
@@ -900,6 +900,7 @@ public class PatternHopFactory {
             newEdge.setTraversalTime(pathway.calculateTraversalTime());
             newEdge.setWheelchairTraversalTime(pathway.calculateWheelchairTraversalTime());
             newEdge.setDistance(pathway.getLength());
+            newEdge.setName(pathway.getSignpostedAs());
         }
     }
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
@@ -895,11 +895,11 @@ public class PatternHopFactory {
         for (Pathway pathway : transitService.getAllPathways()) {
             Vertex fromVertex = context.stationStopNodes.get(pathway.getFromStop());
             Vertex toVertex = context.stationStopNodes.get(pathway.getToStop());
-            if (pathway.isWheelchairTraversalTimeSet()) {
-                new PathwayEdge(fromVertex, toVertex, pathway.getTraversalTime(), pathway.getWheelchairTraversalTime());
-            } else {
-                new PathwayEdge(fromVertex, toVertex, pathway.getTraversalTime());
-            }
+
+            PathwayEdge newEdge = new PathwayEdge(fromVertex, toVertex);
+            newEdge.setTraversalTime(pathway.calculateTraversalTime());
+            newEdge.setWheelchairTraversalTime(pathway.calculateWheelchairTraversalTime());
+            newEdge.setDistance(pathway.getLength());
         }
     }
 

--- a/src/test/java/org/opentripplanner/gtfs/mapping/PathwayMapperTest.java
+++ b/src/test/java/org/opentripplanner/gtfs/mapping/PathwayMapperTest.java
@@ -18,7 +18,7 @@ public class PathwayMapperTest {
 
     private static final AgencyAndId AGENCY_AND_ID = new AgencyAndId("A", "1");
 
-    private static final int PATHWAY_TYPE = 2;
+    private static final int PATHWAY_MODE = 2;
 
     private static final int TRAVERSAL_TIME = 3000;
 
@@ -37,7 +37,7 @@ public class PathwayMapperTest {
         PATHWAY.setId(AGENCY_AND_ID);
         PATHWAY.setFromStop(FROM_STOP);
         PATHWAY.setToStop(TO_STOP);
-        PATHWAY.setPathwayType(PATHWAY_TYPE);
+        PATHWAY.setPathwayMode(PATHWAY_MODE);
         PATHWAY.setTraversalTime(TRAVERSAL_TIME);
         PATHWAY.setWheelchairTraversalTime(WHEELCHAIR_TRAVERSAL_TIME);
     }
@@ -58,9 +58,9 @@ public class PathwayMapperTest {
         assertEquals("A_1", result.getId().toString());
         assertNotNull(result.getFromStop());
         assertNotNull(result.getToStop());
-        assertEquals(PATHWAY_TYPE, result.getPathwayType());
-        assertEquals(TRAVERSAL_TIME, result.getTraversalTime());
-        assertEquals(WHEELCHAIR_TRAVERSAL_TIME, result.getWheelchairTraversalTime());
+        assertEquals(PATHWAY_MODE, result.getPathwayMode());
+        assertEquals(TRAVERSAL_TIME, result.calculateTraversalTime());
+        assertEquals(WHEELCHAIR_TRAVERSAL_TIME, result.calculateWheelchairTraversalTime());
     }
 
     @Test
@@ -73,8 +73,8 @@ public class PathwayMapperTest {
         assertNotNull(result.getId());
         assertNull(result.getFromStop());
         assertNull(result.getToStop());
-        assertEquals(0, result.getPathwayType());
-        assertEquals(0, result.getTraversalTime());
+        assertEquals(0, result.getPathwayMode());
+        assertEquals(0, result.calculateTraversalTime());
         assertFalse(result.isWheelchairTraversalTimeSet());
     }
 


### PR DESCRIPTION
Ticket: [add support for new pathways.txt specification](https://app.asana.com/0/810933294009540/1115551179980222)

Concerns:
- [Python code](https://github.com/mbta/gtfs_creator/blob/gtfs-creator2/gtfs_creator2/pathways/travel_time.py) linked to the ticket has support for calculating traversal times for slopes. It seems that we don't have this data for pathways as of now, so it's not implemented here.
- It seems that we currently don't have negative stair count anywhere despite the fact that [google spec](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#pathwaystxt) says it should be negative for cases when a rider walks down the stairs. The walking speed is obviously different for cases when rider goes up and when they go down -- and this is supported in the python code -- but since we only have positive stair counts, we'll always assume that rider is going up
- I'm not fully sure how to test it, asked @jfabi in slack. All in all, pathways are displayed for the trip plans (but they used to be displayed before as well), but I'm not sure if they are displayed as expected: 

![image](https://user-images.githubusercontent.com/45011335/56152811-ab8c5a00-5f82-11e9-8bb9-68807ea0285b.png)
![image](https://user-images.githubusercontent.com/45011335/56152815-afb87780-5f82-11e9-9050-dd1733b565b7.png)
