### PR TITLE
Handle boarding and alighting separately

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
@@ -136,8 +136,13 @@ public class TransitBoardAlight extends TablePatternEdge implements OnboardEdge 
         }
 
         for (AlertPatch alertPatch: options.getRoutingContext().graph.getAlertPatches(this)) {
-            if ((alertPatch.cannotBoard() || alertPatch.cannotAlight()) && alertPatch.displayDuring(s0)) {
-                return null;
+            if (alertPatch.displayDuring(s0)) {
+                if (alertPatch.cannotBoard() && boarding) {
+                    return null;
+                }
+                else if (alertPatch.cannotAlight() && !boarding) {
+                    return null;
+                }
             }
         }
 


### PR DESCRIPTION
Ticket: [Trip planner doesn't handle RL disruption correctly](https://app.asana.com/0/810933294009540/1119661448618572)

Fixing the previously introduced error - we should handle boarding and alighting separately. 

**Before** (note that it doesn't offer to board at Harward, which should be possible if we go southbound):
![image](https://user-images.githubusercontent.com/45011335/56610063-9fd11100-65dc-11e9-93be-7a8ac48b1216.png)

**After**:
![image](https://user-images.githubusercontent.com/45011335/56610170-dc9d0800-65dc-11e9-9038-df2380b5dce2.png)

![image](https://user-images.githubusercontent.com/45011335/56610204-eaeb2400-65dc-11e9-9cdf-c9737df911d4.png)

