### PR TITLE
Fixing alert logic for alerts w/ RIDE activity 

### DIFF
--- a/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
@@ -13,11 +13,14 @@ import com.google.transit.realtime.GtfsRealtime;
 import org.opentripplanner.model.*;
 import org.opentripplanner.api.adapters.AgencyAndIdAdapter;
 import org.opentripplanner.routing.core.State;
+import org.opentripplanner.routing.edgetype.PatternDwell;
 import org.opentripplanner.routing.edgetype.PreAlightEdge;
 import org.opentripplanner.routing.edgetype.PreBoardEdge;
 import org.opentripplanner.routing.edgetype.TripPattern;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.vertextype.PatternArriveVertex;
+import org.opentripplanner.routing.vertextype.PatternDepartVertex;
 import org.opentripplanner.routing.vertextype.TransitStop;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -165,9 +168,15 @@ public class AlertPatch implements Serializable {
                         }
                     }
 
-                    for (int i = 0; i < tripPattern.hopEdges.length; i++) {
-                        if (stop == null || stop.equals(tripPattern.hopEdges[i].getBeginStop())) {
-                            graph.addAlertPatch(tripPattern.hopEdges[i], this);
+                    for (int i = 0; i < tripPattern.dwellEdges.length; i++) {
+                        PatternDwell dwellEdge = tripPattern.dwellEdges[i];
+
+                        if (dwellEdge != null) {
+                            Stop fromv = ((PatternArriveVertex) dwellEdge.getFromVertex()).getStop();
+                            Stop tov = ((PatternDepartVertex) dwellEdge.getToVertex()).getStop();
+                            if (stop == null || (stop.equals(fromv) && stop.equals(tov))) {
+                                graph.addAlertPatch(tripPattern.dwellEdges[i], this);
+                            }
                         }
                     }
                 }
@@ -232,9 +241,15 @@ public class AlertPatch implements Serializable {
                         }
                     }
 
-                    for (int i = 0; i < tripPattern.hopEdges.length; i++) {
-                        if (stop == null || stop.equals(tripPattern.hopEdges[i].getBeginStop())) {
-                            graph.removeAlertPatch(tripPattern.hopEdges[i], this);
+                    for (int i = 0; i < tripPattern.dwellEdges.length; i++) {
+                        PatternDwell dwellEdge = tripPattern.dwellEdges[i];
+
+                        if (dwellEdge != null) {
+                            Stop fromv = ((PatternArriveVertex) dwellEdge.getFromVertex()).getStop();
+                            Stop tov = ((PatternDepartVertex) dwellEdge.getToVertex()).getStop();
+                            if (stop == null || (stop.equals(fromv) && stop.equals(tov))) {
+                                graph.removeAlertPatch(tripPattern.dwellEdges[i], this);
+                            }
                         }
                     }
                 }

--- a/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
+++ b/src/main/java/org/opentripplanner/routing/alertpatch/AlertPatch.java
@@ -166,7 +166,7 @@ public class AlertPatch implements Serializable {
                     }
 
                     for (int i = 0; i < tripPattern.hopEdges.length; i++) {
-                        if (stop == null || stop.equals(tripPattern.hopEdges[i].getEndStop())) {
+                        if (stop == null || stop.equals(tripPattern.hopEdges[i].getBeginStop())) {
                             graph.addAlertPatch(tripPattern.hopEdges[i], this);
                         }
                     }
@@ -233,7 +233,7 @@ public class AlertPatch implements Serializable {
                     }
 
                     for (int i = 0; i < tripPattern.hopEdges.length; i++) {
-                        if (stop == null || stop.equals(tripPattern.hopEdges[i].getEndStop())) {
+                        if (stop == null || stop.equals(tripPattern.hopEdges[i].getBeginStop())) {
                             graph.removeAlertPatch(tripPattern.hopEdges[i], this);
                         }
                     }

--- a/src/main/java/org/opentripplanner/routing/edgetype/PatternDwell.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PatternDwell.java
@@ -2,6 +2,7 @@ package org.opentripplanner.routing.edgetype;
 
 import java.util.Locale;
 import org.opentripplanner.gtfs.GtfsLibrary;
+import org.opentripplanner.routing.alertpatch.AlertPatch;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -50,6 +51,12 @@ public class PatternDwell extends TablePatternEdge implements OnboardEdge, Dwell
     }
 
     public State traverse(State state0) {
+        for (AlertPatch alertPatch: state0.getOptions().getRoutingContext().graph.getAlertPatches(this)) {
+            if (alertPatch.cannotRideThrough() && alertPatch.displayDuring(state0)) {
+                return null;
+            }
+        }
+
         //int trip = state0.getTrip();
         TripTimes tripTimes = state0.getTripTimes();
         int dwellTime = tripTimes.getDwellTime(stopIndex);
@@ -62,6 +69,12 @@ public class PatternDwell extends TablePatternEdge implements OnboardEdge, Dwell
 
     @Override
     public State optimisticTraverse(State s0) {
+        for (AlertPatch alertPatch: s0.getOptions().getRoutingContext().graph.getAlertPatches(this)) {
+            if (alertPatch.cannotRideThrough() && alertPatch.displayDuring(s0)) {
+                return null;
+            }
+        }
+
         int dwellTime = getPattern().scheduledTimetable.getBestDwellTime(stopIndex);
         StateEditor s1 = s0.edit(this);
         s1.incrementTimeInSeconds(dwellTime);

--- a/src/main/java/org/opentripplanner/routing/edgetype/PatternHop.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/PatternHop.java
@@ -5,7 +5,6 @@ import org.opentripplanner.model.Stop;
 import org.opentripplanner.common.geometry.GeometryUtils;
 import org.opentripplanner.common.geometry.SphericalDistanceLibrary;
 import org.opentripplanner.gtfs.GtfsLibrary;
-import org.opentripplanner.routing.alertpatch.AlertPatch;
 import org.opentripplanner.routing.core.RoutingRequest;
 import org.opentripplanner.routing.core.State;
 import org.opentripplanner.routing.core.StateEditor;
@@ -66,12 +65,6 @@ public class PatternHop extends TablePatternEdge implements OnboardEdge, HopEdge
             }
         }
 
-        for (AlertPatch alertPatch: options.getRoutingContext().graph.getAlertPatches(this)) {
-            if (alertPatch.cannotRideThrough() && alertPatch.displayDuring(state0)) {
-                return null;
-            }
-        }
-
     	int runningTime = getPattern().scheduledTimetable.getBestRunningTime(stopIndex);
     	StateEditor s1 = state0.edit(this);
     	s1.incrementTimeInSeconds(runningTime);
@@ -97,12 +90,6 @@ public class PatternHop extends TablePatternEdge implements OnboardEdge, HopEdge
         if (!options.bannedStopsHard.isEmpty()) {
             if (options.bannedStopsHard.matches(((PatternStopVertex) fromv).getStop())
                     || options.bannedStopsHard.matches(((PatternStopVertex) tov).getStop())) {
-                return null;
-            }
-        }
-
-        for (AlertPatch alertPatch: options.getRoutingContext().graph.getAlertPatches(this)) {
-            if (alertPatch.cannotRideThrough() && alertPatch.displayDuring(s0)) {
                 return null;
             }
         }


### PR DESCRIPTION
Ticket: [Trip planner doesn't allow to alight at Quincy Center during disruptions](https://app.asana.com/0/810933294009540/1122867100192379)

It was not right to use `PatternHop`<sup>[1](#myfootnote1)</sup> edges to attach alerts w/ `RIDE` activity because this activity forbids passing _though_ stops not _between_ stops; we should use `PatternDwell`<sup>[2](#myfootnote2)</sup> edges instead. 

<a name="myfootnote1">1</a>: _A transit vehicle's journey between departure at one stop and arrival at the next_
<a name="myfootnote2">2</a>: _Models waiting in a station on a vehicle_

**Before** (😳):
![image](https://user-images.githubusercontent.com/45011335/57645298-f8684e00-758b-11e9-986c-453c1a6f4aa9.png)

**After**:
![image](https://user-images.githubusercontent.com/45011335/57645327-04eca680-758c-11e9-88a7-a1458e63d7cd.png)
![image](https://user-images.githubusercontent.com/45011335/57648567-d5da3300-7593-11e9-8b84-00540faef14f.png)
