### PR TITLE
Only allow to use GTFS transfers after alighting from a transit vehicle

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
@@ -38,11 +38,8 @@ public class SimpleTransfer extends Edge {
 
     @Override
     public State traverse(State s0) {
-        // Forbid taking shortcuts composed of two transfers in a row
-        if (s0.backEdge instanceof SimpleTransfer) {
-            return null;
-        }
-        if (s0.backEdge instanceof StreetTransitLink) {
+        // only allow to use TransferEdges when already on a transit vehicle and not on a street level
+        if (!(s0.backEdge instanceof PreAlightEdge)) {
             return null;
         }
         if(distance > s0.getOptions().maxTransferWalkDistance) {

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransferEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransferEdge.java
@@ -75,6 +75,9 @@ public class TransferEdge extends Edge {
            but the default Pathparser is currently very hard to read because
            we need a complement operator. */
         if (s0.getBackEdge() instanceof TransferEdge) return null;
+
+        // only allow to use TransferEdges when already on a transit vehicle and not on a street level
+        if (!(s0.getBackEdge() instanceof PreAlightEdge)) return null;
         if (s0.getOptions().wheelchairAccessible && !wheelchairAccessible) return null;
         if (this.getDistance() > s0.getOptions().maxTransferWalkDistance) return null;
         StateEditor s1 = s0.edit(this);

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransferEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransferEdge.java
@@ -71,11 +71,6 @@ public class TransferEdge extends Edge {
     }
 
     public State traverse(State s0) {
-        /* Disallow chaining of transfer edges. TODO: This should really be guaranteed by the PathParser
-           but the default Pathparser is currently very hard to read because
-           we need a complement operator. */
-        if (s0.getBackEdge() instanceof TransferEdge) return null;
-
         // only allow to use TransferEdges when already on a transit vehicle and not on a street level
         if (!(s0.getBackEdge() instanceof PreAlightEdge)) return null;
         if (s0.getOptions().wheelchairAccessible && !wheelchairAccessible) return null;


### PR DESCRIPTION
Ticket: [Ignore transfers where riders are not alighting from a transit vehicle](https://app.asana.com/0/810933294009540/1124337345177780/f)

This PR modifies traversal behavior for two edge types:
1. `TransferEdge` - represents transfers read from GTFS.
2. `SimpleTransfer` - auto-generated transfers between nearby stops (not read from GTFS). 

Basically it only allows traversal (meaning including into trip plan) if previous edge is an instance of `PreAlightEdge`, which is an edge type representing riders' alighting from transit vehicles. 

Before vs After:
![image](https://user-images.githubusercontent.com/45011335/58372050-03a16f00-7ee6-11e9-8da6-f866d1a76982.png)

I did some random checks and everything appears OK, but @jfabi or @handorff do you may be have any trip plan examples from our recent conversation, where it would make sense to use transfers not only when alighting from a transit vehicle? 
