### PR TITLE
Fixing transfer edges traversal

### DIFF
--- a/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
@@ -39,8 +39,11 @@ public class SimpleTransfer extends Edge {
     @Override
     public State traverse(State s0) {
         // only allow to use TransferEdges when already on a transit vehicle and not on a street level
-        if (!(s0.backEdge instanceof PreAlightEdge)) {
-            return null;
+        if (s0.getOptions().arriveBy) {
+            if (s0.getBackEdge() instanceof TransferEdge || s0.getBackEdge() instanceof SimpleTransfer) return null;
+        }
+        else {
+            if (!(s0.getBackEdge() instanceof PreAlightEdge)) return null;
         }
         if(distance > s0.getOptions().maxTransferWalkDistance) {
             return null;

--- a/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/SimpleTransfer.java
@@ -40,11 +40,12 @@ public class SimpleTransfer extends Edge {
     public State traverse(State s0) {
         // only allow to use TransferEdges when already on a transit vehicle and not on a street level
         if (s0.getOptions().arriveBy) {
-            if (s0.getBackEdge() instanceof TransferEdge || s0.getBackEdge() instanceof SimpleTransfer) return null;
+            if (!(s0.getBackEdge() instanceof PreBoardEdge)) return null;
         }
         else {
             if (!(s0.getBackEdge() instanceof PreAlightEdge)) return null;
         }
+
         if(distance > s0.getOptions().maxTransferWalkDistance) {
             return null;
         }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransferEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransferEdge.java
@@ -73,7 +73,7 @@ public class TransferEdge extends Edge {
     public State traverse(State s0) {
         // only allow to use TransferEdges when already on a transit vehicle and not on a street level
         if (s0.getOptions().arriveBy) {
-            if (s0.getBackEdge() instanceof TransferEdge || s0.getBackEdge() instanceof SimpleTransfer) return null;
+            if (!(s0.getBackEdge() instanceof PreBoardEdge)) return null;
         }
         else {
             if (!(s0.getBackEdge() instanceof PreAlightEdge)) return null;

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransferEdge.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransferEdge.java
@@ -72,7 +72,12 @@ public class TransferEdge extends Edge {
 
     public State traverse(State s0) {
         // only allow to use TransferEdges when already on a transit vehicle and not on a street level
-        if (!(s0.getBackEdge() instanceof PreAlightEdge)) return null;
+        if (s0.getOptions().arriveBy) {
+            if (s0.getBackEdge() instanceof TransferEdge || s0.getBackEdge() instanceof SimpleTransfer) return null;
+        }
+        else {
+            if (!(s0.getBackEdge() instanceof PreAlightEdge)) return null;
+        }
         if (s0.getOptions().wheelchairAccessible && !wheelchairAccessible) return null;
         if (this.getDistance() > s0.getOptions().maxTransferWalkDistance) return null;
         StateEditor s1 = s0.edit(this);


### PR DESCRIPTION
Ticket: [Wrong schedule at early AM hours](https://app.asana.com/0/810933294009540/1124884833509993/f)

It's not actually caused by early AM hours, but rather by the bug, which I've introduced in https://github.com/mbta/OpenTripPlanner/pull/16.

The change works fine when traversing the graph in usual mode, but whenever customers use "arrive by" option, the graph is apparently traversed backwards (that is, from destination stop to initial stop, "back in time"), so the _previous edge_, which we're checking here, would not necessary be on a transit vehicle. 

This PR reverts the algorithm to the old behavior for cases when "arrive by" option is used. 

**Before**:
![image](https://user-images.githubusercontent.com/45011335/58981098-ad62e480-879f-11e9-8cd6-6e40d468597d.png)

**After**:
![image](https://user-images.githubusercontent.com/45011335/58981151-d1262a80-879f-11e9-8304-58a53b6dfc4b.png)
