### PR TITLE
Ignoring pathways with unknown traversal time

### DIFF
--- a/src/main/java/org/opentripplanner/model/Pathway.java
+++ b/src/main/java/org/opentripplanner/model/Pathway.java
@@ -5,7 +5,7 @@ public final class Pathway extends IdentityBean<FeedScopedId> {
 
     private static final long serialVersionUID = -2404871423254094109L;
 
-    private static final int MISSING_VALUE = -999;
+    public static final int MISSING_VALUE = -999;
 
     private FeedScopedId id;
 

--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
@@ -893,6 +893,7 @@ public class PatternHopFactory {
 
     private void loadPathways(Graph graph) {
         for (Pathway pathway : transitService.getAllPathways()) {
+            if (pathway.getTraversalTime() == Pathway.MISSING_VALUE) continue;
             Vertex fromVertex = context.stationStopNodes.get(pathway.getFromStop());
             Vertex toVertex = context.stationStopNodes.get(pathway.getToStop());
             if (pathway.isWheelchairTraversalTimeSet()) {


### PR DESCRIPTION
Tickets: 
- [No airport shuttles in the trip planner](https://app.asana.com/0/810933294009540/1127374532944735/f)
- [Check pathways related warnings during OTP build](https://app.asana.com/0/810933294009540/1125909192820394/f)

The issue was that while new pathways were ignored during trip planning, they were not ignored during the graph building. And there is a step during graph building, where we check whether certain stop is "street-linkable" ([ref](https://github.com/mbta/OpenTripPlanner/blob/master/src/main/java/org/opentripplanner/graph_builder/module/DirectTransferGenerator.java#L94)) and we only create distance-based transfers if it is. And should a stop have any pathways attached to it, it's considered to be not street-linkable (because it's supposed to be linked to the street network through pathways, that is), so this was the reason why we didn't create transfer between airport station (70047) and shuttle bus stop (2502248).

This is now fixed (before vs after):
![image](https://user-images.githubusercontent.com/45011335/59630905-80ee8700-9114-11e9-8672-06dd74cab038.png)
