### PR TITLE
Support for new ignored_alerts.txt GTFS file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -668,7 +668,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-gtfs</artifactId>
-            <version>1.3.67-MBTA</version>
+            <version>1.3.74-MBTA</version>
         </dependency>
         <!-- Processing is used for the debug GUI (though we could probably use just Java2D) -->
         <dependency>

--- a/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/GTFSToOtpTransitServiceMapper.java
@@ -42,6 +42,8 @@ public class GTFSToOtpTransitServiceMapper {
             routeMapper, fareAttributeMapper
     );
 
+    private final IgnoredAlertMapper alertMapper = new IgnoredAlertMapper();
+
     /**
      * Map from GTFS data to the internal OTP model
      */
@@ -68,6 +70,7 @@ public class GTFSToOtpTransitServiceMapper {
         // remove "recommended" transfers as they break the trip plans
         builder.getTransfers().removeIf(t -> t.getTransferType() == 0);
         builder.getTrips().addAll(tripMapper.map(data.getAllTrips()));
+        builder.getIgnoredAlerts().addAll(alertMapper.map(data.getAllIgnoredAlerts()));
 
         return builder.build();
     }

--- a/src/main/java/org/opentripplanner/gtfs/mapping/IgnoredAlertMapper.java
+++ b/src/main/java/org/opentripplanner/gtfs/mapping/IgnoredAlertMapper.java
@@ -1,0 +1,32 @@
+package org.opentripplanner.gtfs.mapping;
+
+import org.opentripplanner.model.IgnoredAlert;
+import org.opentripplanner.util.MapUtils;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Responsible for mapping MBTA GTFS Ignored Alerts entities into the OTP model. */
+class IgnoredAlertMapper {
+
+    private final Map<org.onebusaway.gtfs.model.IgnoredAlert, IgnoredAlert> mappedAlerts = new HashMap<>();
+
+    Collection<IgnoredAlert> map(Collection<org.onebusaway.gtfs.model.IgnoredAlert> alerts) {
+        return MapUtils.mapToList(alerts, this::map);
+    }
+
+    /** Maps from GTFS to OTP model, {@code null} safe.  */
+    IgnoredAlert map(org.onebusaway.gtfs.model.IgnoredAlert orginal) {
+        return orginal == null ? null : mappedAlerts.computeIfAbsent(orginal, this::doMap);
+    }
+
+    private IgnoredAlert doMap(org.onebusaway.gtfs.model.IgnoredAlert rhs) {
+        IgnoredAlert lhs = new IgnoredAlert();
+
+        lhs.setId(rhs.getId());
+        lhs.setDescription(rhs.getDescription());
+
+        return lhs;
+    }
+}

--- a/src/main/java/org/opentripplanner/model/IgnoredAlert.java
+++ b/src/main/java/org/opentripplanner/model/IgnoredAlert.java
@@ -1,0 +1,38 @@
+package org.opentripplanner.model;
+
+public final class IgnoredAlert extends IdentityBean<String> {
+
+    private static final long serialVersionUID = 1L;
+
+    private String id;
+
+    private String description;
+
+    public IgnoredAlert() {
+    }
+
+    public IgnoredAlert(IgnoredAlert a) {
+        this.id = a.id;
+        this.description = a.description;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String toString() {
+        return "<IgnoredAlert " + this.id + ">";
+    }
+}

--- a/src/main/java/org/opentripplanner/model/OtpTransitService.java
+++ b/src/main/java/org/opentripplanner/model/OtpTransitService.java
@@ -53,6 +53,8 @@ public interface OtpTransitService {
 
     Collection<Trip> getAllTrips();
 
+    Collection<IgnoredAlert> getAllIgnoredAlerts();
+
     List<String> getTripAgencyIdsReferencingServiceId(FeedScopedId serviceId);
 
     List<Stop> getStopsForStation(Stop station);

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceBuilder.java
@@ -1,21 +1,6 @@
 package org.opentripplanner.model.impl;
 
-import org.opentripplanner.model.Agency;
-import org.opentripplanner.model.FareAttribute;
-import org.opentripplanner.model.FareRule;
-import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.model.Frequency;
-import org.opentripplanner.model.IdentityBean;
-import org.opentripplanner.model.Pathway;
-import org.opentripplanner.model.Route;
-import org.opentripplanner.model.ServiceCalendar;
-import org.opentripplanner.model.ServiceCalendarDate;
-import org.opentripplanner.model.ShapePoint;
-import org.opentripplanner.model.Stop;
-import org.opentripplanner.model.StopTime;
-import org.opentripplanner.model.Transfer;
-import org.opentripplanner.model.Trip;
-import org.opentripplanner.model.OtpTransitService;
+import org.opentripplanner.model.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,6 +39,8 @@ public class OtpTransitServiceBuilder {
 
     private final List<Trip> trips = new ArrayList<>();
 
+    private final List<IgnoredAlert> ignoredAlerts = new ArrayList<>();
+
     public OtpTransitServiceBuilder() {
     }
 
@@ -76,6 +63,7 @@ public class OtpTransitServiceBuilder {
         stopTimes.addAll(other.getAllStopTimes());
         transfers.addAll(other.getAllTransfers());
         trips.addAll(other.getAllTrips());
+        ignoredAlerts.addAll(other.getAllIgnoredAlerts());
         return this;
     }
 
@@ -135,13 +123,17 @@ public class OtpTransitServiceBuilder {
         return trips;
     }
 
+    public List<IgnoredAlert> getIgnoredAlerts() {
+        return ignoredAlerts;
+    }
+
     public OtpTransitService build() {
 
         createNoneExistentIds();
 
         return new OtpTransitServiceImpl(agencies, calendarDates, calendars, fareAttributes, fareRules,
                 feedInfos, frequencies, pathways, routes, shapePoints, stops, stopTimes, transfers,
-                trips);
+                trips, ignoredAlerts);
     }
 
     private void createNoneExistentIds() {

--- a/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
+++ b/src/main/java/org/opentripplanner/model/impl/OtpTransitServiceImpl.java
@@ -1,22 +1,7 @@
 /* This file is based on code copied from project OneBusAway, see the LICENSE file for further information. */
 package org.opentripplanner.model.impl;
 
-import org.opentripplanner.model.Agency;
-import org.opentripplanner.model.FeedScopedId;
-import org.opentripplanner.model.FareAttribute;
-import org.opentripplanner.model.FareRule;
-import org.opentripplanner.model.FeedInfo;
-import org.opentripplanner.model.Frequency;
-import org.opentripplanner.model.Pathway;
-import org.opentripplanner.model.Route;
-import org.opentripplanner.model.ServiceCalendar;
-import org.opentripplanner.model.ServiceCalendarDate;
-import org.opentripplanner.model.ShapePoint;
-import org.opentripplanner.model.Stop;
-import org.opentripplanner.model.StopTime;
-import org.opentripplanner.model.Transfer;
-import org.opentripplanner.model.Trip;
-import org.opentripplanner.model.OtpTransitService;
+import org.opentripplanner.model.*;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,6 +59,8 @@ class OtpTransitServiceImpl implements OtpTransitService {
 
     private Collection<Trip> trips;
 
+    private Collection<IgnoredAlert> ignoredAlerts;
+
     // Indexes
     private Map<FeedScopedId, List<String>> tripAgencyIdsByServiceId = null;
 
@@ -96,7 +83,7 @@ class OtpTransitServiceImpl implements OtpTransitService {
             List<FareRule> fareRules, List<FeedInfo> feedInfos, List<Frequency> frequencies,
             List<Pathway> pathways, List<Route> routes, List<ShapePoint> shapePoints,
             List<Stop> stops, List<StopTime> stopTimes, List<Transfer> transfers,
-            List<Trip> trips) {
+            List<Trip> trips, List<IgnoredAlert> ignoredAlerts) {
         this.agencies = nullSafeUnmodifiableList(agencies);
         this.calendarDates = nullSafeUnmodifiableList(calendarDates);
         this.calendars = nullSafeUnmodifiableList(calendars);
@@ -111,6 +98,7 @@ class OtpTransitServiceImpl implements OtpTransitService {
         this.stopTimes = nullSafeUnmodifiableList(stopTimes);
         this.transfers = nullSafeUnmodifiableList(transfers);
         this.trips = nullSafeUnmodifiableList(trips);
+        this.ignoredAlerts = nullSafeUnmodifiableList(ignoredAlerts);
     }
 
     @Override
@@ -181,6 +169,11 @@ class OtpTransitServiceImpl implements OtpTransitService {
     @Override
     public Collection<Pathway> getAllPathways() {
         return pathways;
+    }
+
+    @Override
+    public Collection<IgnoredAlert> getAllIgnoredAlerts() {
+        return ignoredAlerts;
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/factory/PatternHopFactory.java
@@ -288,6 +288,8 @@ public class PatternHopFactory {
             fareServiceFactory = new DefaultFareServiceFactory();
         }
         fareServiceFactory.processGtfs(transitService);
+
+        graph.ignoredAlerts.addAll(transitService.getAllIgnoredAlerts());
         
         // TODO: Why are we loading stops? The Javadoc above says this method assumes stops are aleady loaded.
         loadStops(graph);

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -23,13 +23,9 @@ import org.apache.commons.math3.stat.descriptive.rank.Median;
 import org.joda.time.DateTime;
 import org.objenesis.strategy.SerializingInstantiatorStrategy;
 import org.opentripplanner.calendar.impl.CalendarServiceImpl;
-import org.opentripplanner.model.Agency;
-import org.opentripplanner.model.FeedScopedId;
-import org.opentripplanner.model.Stop;
-import org.opentripplanner.model.FeedInfo;
+import org.opentripplanner.model.*;
 import org.opentripplanner.model.calendar.CalendarServiceData;
 import org.opentripplanner.model.calendar.ServiceDate;
-import org.opentripplanner.model.CalendarService;
 import org.opentripplanner.analyst.core.GeometryIndex;
 import org.opentripplanner.analyst.request.SampleFactory;
 import org.opentripplanner.common.MavenVersion;
@@ -38,7 +34,6 @@ import org.opentripplanner.common.geometry.GraphUtils;
 import org.opentripplanner.graph_builder.annotation.GraphBuilderAnnotation;
 import org.opentripplanner.graph_builder.annotation.NoFutureDates;
 import org.opentripplanner.kryo.HashBiMapSerializer;
-import org.opentripplanner.model.GraphBundle;
 import org.opentripplanner.profile.StopClusterMode;
 import org.opentripplanner.routing.alertpatch.AlertPatch;
 import org.opentripplanner.routing.core.MortonVertexComparatorFactory;
@@ -206,6 +201,9 @@ public class Graph implements Serializable {
 
     /** Parent stops **/
     public Map<FeedScopedId, Stop> parentStopById = new HashMap<>();
+
+    /** MBTA alerts to ignore **/
+    public Collection<IgnoredAlert> ignoredAlerts = new ArrayList<>();
 
     public Graph(Graph basedOn) {
         this();

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
@@ -3,12 +3,14 @@ package org.opentripplanner.updater.alerts;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.transit.realtime.GtfsRealtime;
 import org.apache.commons.io.IOUtils;
+import org.opentripplanner.model.IgnoredAlert;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.impl.AlertPatchServiceImpl;
 import org.opentripplanner.routing.services.AlertPatchService;
@@ -16,7 +18,6 @@ import org.opentripplanner.updater.GraphUpdaterManager;
 import org.opentripplanner.updater.GraphWriterRunnable;
 import org.opentripplanner.updater.GtfsRealtimeFuzzyTripMatcher;
 import org.opentripplanner.updater.PollingGraphUpdater;
-import org.opentripplanner.util.ArrayUtils;
 import org.opentripplanner.util.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,8 +44,6 @@ public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
 
     private AlertsUpdateHandler updateHandler = null;
 
-    private String[] blacklist = new String[0];
-
     @Override
     public void setGraphUpdaterManager(GraphUpdaterManager updaterManager) {
         this.updaterManager = updaterManager;
@@ -64,9 +63,6 @@ public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
         this.feedId = config.path("feedId").asText();
         if (config.path("fuzzyTripMatching").asBoolean(false)) {
             this.fuzzyTripMatcher = new GtfsRealtimeFuzzyTripMatcher(graph.index);
-        }
-        if (config.path("blacklist") != null) {
-            this.blacklist = new ObjectMapper().convertValue(config.path("blacklist"), String[].class);
         }
         LOG.info("Creating enhanced real-time alert (json) updater running every {} seconds : {}", pollingPeriodSeconds, url);
     }
@@ -98,16 +94,22 @@ public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
                 return;
             }
 
-            List<GtfsRealtime.FeedEntity> entities = feed
-                    .getEntityList()
-                    .stream()
-                    .filter(e -> e.hasId() && !ArrayUtils.contains(blacklist, e.getId()))
-                    .collect(Collectors.toList());
-
             // Handle update in graph writer runnable
             updaterManager.execute(new GraphWriterRunnable() {
                 @Override
                 public void run(Graph graph) {
+                    Set<String> blacklist = graph
+                            .ignoredAlerts
+                            .stream()
+                            .map(IgnoredAlert::getId)
+                            .collect(Collectors.toSet());
+
+                    List<GtfsRealtime.FeedEntity> entities = feed
+                            .getEntityList()
+                            .stream()
+                            .filter(e -> e.hasId() && !blacklist.contains(e.getId()))
+                            .collect(Collectors.toList());
+
                     updateHandler.update(entities);
                 }
             });

--- a/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
+++ b/src/main/java/org/opentripplanner/updater/alerts/GtfsEnhancedRealtimeAlertsUpdater.java
@@ -98,7 +98,7 @@ public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
             updaterManager.execute(new GraphWriterRunnable() {
                 @Override
                 public void run(Graph graph) {
-                    Set<String> blacklist = graph
+                    Set<String> ignoredList = graph
                             .ignoredAlerts
                             .stream()
                             .map(IgnoredAlert::getId)
@@ -107,7 +107,7 @@ public class GtfsEnhancedRealtimeAlertsUpdater extends PollingGraphUpdater {
                     List<GtfsRealtime.FeedEntity> entities = feed
                             .getEntityList()
                             .stream()
-                            .filter(e -> e.hasId() && !blacklist.contains(e.getId()))
+                            .filter(e -> e.hasId() && !ignoredList.contains(e.getId()))
                             .collect(Collectors.toList());
 
                     updateHandler.update(entities);


### PR DESCRIPTION
Ticket: [use list of ignored alerts from GTFS](https://app.asana.com/0/810933294009540/1132715413652352/f)

This ended up having much more code changes than I initially anticipated because alerts loading happens in realtime, while gtfs parsing is happening during graph build (which happens only once, during deployment). 

In general, nothing is expected to change after this PR from customer perspective, we're just moving alerts from config file to be read from GTFS bundle. 