### PR TITLE
Calculating itinerary start time based on trip legs

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -140,7 +140,7 @@ public abstract class GraphPathToTripPlanConverter {
         State[] states = new State[path.states.size()];
         states = path.states.toArray(states);
 
-        State lastState = getLastState(states);
+        State lastTransitState = getLastTransitState(states);
 
         Edge[] edges = new Edge[path.edges.size()];
         edges = path.edges.toArray(edges);
@@ -163,17 +163,17 @@ public abstract class GraphPathToTripPlanConverter {
 
         fixupLegs(itinerary.legs, legsStates);
 
-        itinerary.duration = lastState.getElapsedTimeSeconds();
+        itinerary.duration = lastTransitState.getElapsedTimeSeconds();
         itinerary.startTime = getStartTime(states);
-        itinerary.endTime = makeCalendar(lastState);
+        itinerary.endTime = makeCalendar(lastTransitState);
 
         calculateTimes(itinerary, states);
 
         calculateElevations(itinerary, edges);
 
-        itinerary.walkDistance = lastState.getWalkDistance();
-
-        itinerary.transfers = lastState.getNumBoardings();
+        State finalState = path.states.getLast();
+        itinerary.walkDistance = finalState.getWalkDistance();
+        itinerary.transfers = finalState.getNumBoardings();
         if (itinerary.transfers > 0 && !(states[0].getVertex() instanceof OnboardDepartVertex)) {
             itinerary.transfers--;
         }
@@ -181,7 +181,7 @@ public abstract class GraphPathToTripPlanConverter {
         return itinerary;
     }
 
-    private static State getLastState(State[] states) {
+    private static State getLastTransitState(State[] states) {
         State lastState = states[states.length - 1];
 
         return Arrays

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -138,8 +138,9 @@ public abstract class GraphPathToTripPlanConverter {
         Itinerary itinerary = new Itinerary();
 
         State[] states = new State[path.states.size()];
-        State lastState = path.states.getLast();
         states = path.states.toArray(states);
+
+        State lastState = getLastState(states);
 
         Edge[] edges = new Edge[path.edges.size()];
         edges = path.edges.toArray(edges);
@@ -178,6 +179,17 @@ public abstract class GraphPathToTripPlanConverter {
         }
 
         return itinerary;
+    }
+
+    private static State getLastState(State[] states) {
+        State lastState = states[states.length - 1];
+
+        return Arrays
+                .stream(states)
+                .filter(s -> s.backEdge instanceof TransitBoardAlight || s.backEdge instanceof StreetEdge)
+                .reduce((first, second) -> second)
+                .orElse(lastState)
+                .getBackState();
     }
 
     private static Calendar getStartTime(State[] states) {

--- a/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
+++ b/src/main/java/org/opentripplanner/api/resource/GraphPathToTripPlanConverter.java
@@ -163,7 +163,7 @@ public abstract class GraphPathToTripPlanConverter {
         fixupLegs(itinerary.legs, legsStates);
 
         itinerary.duration = lastState.getElapsedTimeSeconds();
-        itinerary.startTime = makeCalendar(states[0]);
+        itinerary.startTime = getStartTime(states);
         itinerary.endTime = makeCalendar(lastState);
 
         calculateTimes(itinerary, states);
@@ -178,6 +178,15 @@ public abstract class GraphPathToTripPlanConverter {
         }
 
         return itinerary;
+    }
+
+    private static Calendar getStartTime(State[] states) {
+        Optional<State> firstStep = Arrays
+                .stream(states)
+                // either boarding or walking
+                .filter(s -> s.backEdge instanceof TransitBoardAlight || s.backEdge instanceof StreetEdge)
+                .findFirst();
+        return makeCalendar(firstStep.orElse(states[0]));
     }
 
     private static Calendar makeCalendar(State state) {


### PR DESCRIPTION
Ticket: [Some plans with too-early start times](https://app.asana.com/0/810933294009540/450671048515648/f)

So basically it used to take the start time of the first leg as the itinerary start time even if the first leg was simply waiting (yes, this is treated as a graph edge and hence is a trip leg). This PR is changing this behavior to set itinerary start time either to the time of the first transit boarding (or alighting if traveling "backwards", in "arrive by" mode) or to the time of the first walking leg. Note that in case of walking we start immediately on requested time, so trips that involve initial walking are not going to be affected by this change. If we feel that it's important to change those trip plans as well, I'd rather do it in separate ticket as it most probably is going to involve more drastic changes.

**Before**:
![image](https://user-images.githubusercontent.com/45011335/62722369-45698e00-b9dc-11e9-9544-e20b62f100b6.png)

**After:**
![image](https://user-images.githubusercontent.com/45011335/62722502-8661a280-b9dc-11e9-8919-875ef095207c.png)

I ran the newly added integration tests and all of them expectedly failed. However, when I tweaked them to ignore `startTime` values, all of them passed, so it seems to be working as intended. I've spot checked few of those `starTime` values and new version seems to behave as expected. 