### PR TITLE
Treating shuttle routes as 'unpreferred'

### DIFF
--- a/src/main/java/org/opentripplanner/model/Route.java
+++ b/src/main/java/org/opentripplanner/model/Route.java
@@ -1,6 +1,8 @@
 /* This file is based on code copied from project OneBusAway, see the LICENSE file for further information. */
 package org.opentripplanner.model;
 
+import java.util.Optional;
+
 public final class Route extends IdentityBean<FeedScopedId> {
 
     private static final long serialVersionUID = 1L;
@@ -165,6 +167,10 @@ public final class Route extends IdentityBean<FeedScopedId> {
 
     public void setEligibilityRestricted(int eligibilityRestricted) {
         this.eligibilityRestricted = eligibilityRestricted;
+    }
+
+    public boolean isShuttle() {
+        return Optional.ofNullable(desc).orElse("").equals("Rail Replacement Bus");
     }
 
     @Override

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -313,6 +313,9 @@ public class RoutingRequest implements Cloneable, Serializable {
     /** Penalty for using a non-preferred transfer */
     public int nonpreferredTransferPenalty = 180;
 
+    /** Penalty for using MBTA shuttles **/
+    public int shuttlePenalty = 600;
+
     /**
      * For the bike triangle, how important time is. 
      * triangleTimeFactor+triangleSlopeFactor+triangleSafetyFactor == 1
@@ -1423,8 +1426,7 @@ public class RoutingRequest implements Cloneable, Serializable {
         }
         boolean isUnpreferedRoute  = unpreferredRoutes   != null && unpreferredRoutes.matches(route);
         boolean isUnpreferedAgency = unpreferredAgencies != null && unpreferredAgencies.contains(agencyID);
-        boolean isShuttle = Optional.ofNullable(route.getDesc()).orElse("").equals("Rail Replacement Bus");
-        if (isUnpreferedRoute || isUnpreferedAgency || isShuttle) {
+        if (isUnpreferedRoute || isUnpreferedAgency) {
             preferences_penalty += useUnpreferredRoutesPenalty;
         }
         return preferences_penalty;

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -1423,7 +1423,8 @@ public class RoutingRequest implements Cloneable, Serializable {
         }
         boolean isUnpreferedRoute  = unpreferredRoutes   != null && unpreferredRoutes.matches(route);
         boolean isUnpreferedAgency = unpreferredAgencies != null && unpreferredAgencies.contains(agencyID);
-        if (isUnpreferedRoute || isUnpreferedAgency) {
+        boolean isShuttle = route.getId().getId().startsWith("Shuttle-");
+        if (isUnpreferedRoute || isUnpreferedAgency || isShuttle) {
             preferences_penalty += useUnpreferredRoutesPenalty;
         }
         return preferences_penalty;

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -1423,7 +1423,7 @@ public class RoutingRequest implements Cloneable, Serializable {
         }
         boolean isUnpreferedRoute  = unpreferredRoutes   != null && unpreferredRoutes.matches(route);
         boolean isUnpreferedAgency = unpreferredAgencies != null && unpreferredAgencies.contains(agencyID);
-        boolean isShuttle = route.getId().getId().startsWith("Shuttle-");
+        boolean isShuttle = Optional.ofNullable(route.getDesc()).orElse("").equals("Rail Replacement Bus");
         if (isUnpreferedRoute || isUnpreferedAgency || isShuttle) {
             preferences_penalty += useUnpreferredRoutesPenalty;
         }

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -12,8 +12,8 @@ import org.opentripplanner.routing.error.TrivialPathException;
 import org.opentripplanner.routing.graph.Edge;
 import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.graph.Vertex;
+import org.opentripplanner.routing.impl.AvoidShuttlesComparator;
 import org.opentripplanner.routing.impl.DurationComparator;
-import org.opentripplanner.routing.impl.PathComparator;
 import org.opentripplanner.routing.request.BannedStopSet;
 import org.opentripplanner.routing.spt.DominanceFunction;
 import org.opentripplanner.routing.spt.GraphPath;
@@ -1498,7 +1498,7 @@ public class RoutingRequest implements Cloneable, Serializable {
         if ("duration".equals(pathComparator)) {
             return new DurationComparator();
         }
-        return new PathComparator(compareStartTimes);
+        return new AvoidShuttlesComparator(compareStartTimes);
     }
 
 }

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
@@ -331,7 +331,9 @@ public class TransitBoardAlight extends TablePatternEdge implements OnboardEdge 
                         options.nonpreferredTransferPenalty);
             }
 
-            s1.incrementWeight(preferences_penalty + transferPenalty);
+            int shuttlePenalty = getPattern().route.isShuttle() ? options.shuttlePenalty : 0;
+
+            s1.incrementWeight(preferences_penalty + transferPenalty + shuttlePenalty);
 
             // when reverse optimizing, the board cost needs to be applied on
             // alight to prevent state domination due to free alights

--- a/src/main/java/org/opentripplanner/routing/impl/AvoidShuttlesComparator.java
+++ b/src/main/java/org/opentripplanner/routing/impl/AvoidShuttlesComparator.java
@@ -1,0 +1,29 @@
+package org.opentripplanner.routing.impl;
+
+import org.opentripplanner.routing.edgetype.TransitBoardAlight;
+import org.opentripplanner.routing.spt.GraphPath;
+
+public class AvoidShuttlesComparator extends PathComparator {
+    public AvoidShuttlesComparator(boolean compareStartTimes) {
+        super(compareStartTimes);
+    }
+
+    @Override
+    public int compare(GraphPath o1, GraphPath o2) {
+        boolean o1HasShuttles = hasShuttles(o1);
+        boolean o2HasShuttles = hasShuttles(o2);
+
+        if (o1HasShuttles == o2HasShuttles) return super.compare(o1, o2);
+        // means that if o1 has shuttles then it's "greater" then o2 and hence it goes to the end of the list
+        else return o1HasShuttles ? 1 : -1;
+    }
+
+    private boolean hasShuttles(GraphPath gp) {
+        return gp.edges
+                .stream()
+                .anyMatch(e -> {
+                    if (e instanceof TransitBoardAlight) return ((TransitBoardAlight) e).getPattern().route.isShuttle();
+                    else return false;
+                });
+    }
+}

--- a/src/test/java/org/opentripplanner/routing/core/RoutingRequestTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/RoutingRequestTest.java
@@ -69,9 +69,9 @@ public class RoutingRequestTest {
     @Test
     public void testPreferencesPenaltyForShuttle() {
         FeedScopedId id = new FeedScopedId();
-        id.setId("Shuttle-Shuttle");
         Agency agency = new Agency();
         Route route = new Route();
+        route.setDesc("Rail Replacement Bus");
         Trip trip = new Trip();
         RoutingRequest routingRequest = new RoutingRequest();
 

--- a/src/test/java/org/opentripplanner/routing/core/RoutingRequestTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/RoutingRequestTest.java
@@ -65,20 +65,4 @@ public class RoutingRequestTest {
         route.setAgency(agency);
         assertEquals(0, routingRequest.preferencesPenaltyForRoute(trip.getRoute()));
     }
-
-    @Test
-    public void testPreferencesPenaltyForShuttle() {
-        FeedScopedId id = new FeedScopedId();
-        Agency agency = new Agency();
-        Route route = new Route();
-        route.setDesc("Rail Replacement Bus");
-        Trip trip = new Trip();
-        RoutingRequest routingRequest = new RoutingRequest();
-
-        trip.setRoute(route);
-        route.setId(id);
-        route.setAgency(agency);
-        assertEquals(routingRequest.useUnpreferredRoutesPenalty,
-                routingRequest.preferencesPenaltyForRoute(trip.getRoute()));
-    }
 }

--- a/src/test/java/org/opentripplanner/routing/core/RoutingRequestTest.java
+++ b/src/test/java/org/opentripplanner/routing/core/RoutingRequestTest.java
@@ -65,4 +65,20 @@ public class RoutingRequestTest {
         route.setAgency(agency);
         assertEquals(0, routingRequest.preferencesPenaltyForRoute(trip.getRoute()));
     }
+
+    @Test
+    public void testPreferencesPenaltyForShuttle() {
+        FeedScopedId id = new FeedScopedId();
+        id.setId("Shuttle-Shuttle");
+        Agency agency = new Agency();
+        Route route = new Route();
+        Trip trip = new Trip();
+        RoutingRequest routingRequest = new RoutingRequest();
+
+        trip.setRoute(route);
+        route.setId(id);
+        route.setAgency(agency);
+        assertEquals(routingRequest.useUnpreferredRoutesPenalty,
+                routingRequest.preferencesPenaltyForRoute(trip.getRoute()));
+    }
 }


### PR DESCRIPTION
Ticket: [mark shuttle routes as less preferred in OTP](https://app.asana.com/0/810933294009540/1137714962718721/f)

This seems to be working as intended and I've checked under debugger that it's actually being executed; the problem, however, is that I cannot find any trip plans where this change would make a difference.. Do we have any shuttles, which could be easily avoided by using other routes? I haven't found any such examples. 