### PR TITLE
Allowing to transfer to a station with GTFS pathways but without GTFS transfers

### DIFF
--- a/src/main/java/org/opentripplanner/routing/vertextype/TransitStop.java
+++ b/src/main/java/org/opentripplanner/routing/vertextype/TransitStop.java
@@ -76,12 +76,7 @@ public class TransitStop extends TransitStationStop {
     }
 
     public boolean hasGtfsTransfers() {
-        for (Edge e : this.getOutgoing()) {
-            if (e instanceof TransferEdge || e instanceof PathwayEdge) {
-                return true;
-            }
-        }
-        return false;
+        return this.getOutgoing().stream().anyMatch(e -> e instanceof TransferEdge);
      }
 
     public int getStreetToStopTime() {


### PR DESCRIPTION
Ticket: [investigate trip plan reported by the customer and see why it doesn't suggest Green Line connection](https://app.asana.com/0/810933294009540/1135805648682193/f)

This problem has been introduced in https://github.com/mbta/OpenTripPlanner/pull/3 - not sure why I've decided to exclude station w/ pathways from distance-based transfer generation back then. Now I'm changing the logic to not generate distance based transfers only if either of stops has entries in transfers.txt.

Before vs After:
![image](https://user-images.githubusercontent.com/45011335/64805573-62efc180-d55f-11e9-9f90-992259037d3c.png)

As discussed with @jfabi, I believe that all Newton Highlands pathways should have `traversal_time` populated because as of now it is filled only for the pathways going through one of the doors (which is the farthest door from the bus stop mentioned in the ticket), so we're directing the riders through this door, which is misleading. 

All integration tests pass except for the newly introduced one, which is expected to fail until this change is deployed to production. 
