### PR TITLE
Making shuttle penalty configurable and change it from 600s to 300s

### DIFF
--- a/src/main/java/org/opentripplanner/api/common/RoutingResource.java
+++ b/src/main/java/org/opentripplanner/api/common/RoutingResource.java
@@ -487,6 +487,8 @@ public abstract class RoutingResource {
         if (bikeSwitchCost != null)
             request.bikeSwitchCost = bikeSwitchCost;
 
+        request.mbtaShuttlePenalty = router.mbtaShuttlePenalty;
+
         if (optimize != null) {
             // Optimize types are basically combined presets of routing parameters, except for triangle
             request.setOptimize(optimize);

--- a/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
+++ b/src/main/java/org/opentripplanner/routing/core/RoutingRequest.java
@@ -314,7 +314,7 @@ public class RoutingRequest implements Cloneable, Serializable {
     public int nonpreferredTransferPenalty = 180;
 
     /** Penalty for using MBTA shuttles **/
-    public int shuttlePenalty = 600;
+    public int mbtaShuttlePenalty;
 
     /**
      * For the bike triangle, how important time is. 

--- a/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
+++ b/src/main/java/org/opentripplanner/routing/edgetype/TransitBoardAlight.java
@@ -331,7 +331,7 @@ public class TransitBoardAlight extends TablePatternEdge implements OnboardEdge 
                         options.nonpreferredTransferPenalty);
             }
 
-            int shuttlePenalty = getPattern().route.isShuttle() ? options.shuttlePenalty : 0;
+            int shuttlePenalty = getPattern().route.isShuttle() ? options.mbtaShuttlePenalty : 0;
 
             s1.incrementWeight(preferences_penalty + transferPenalty + shuttlePenalty);
 

--- a/src/main/java/org/opentripplanner/standalone/Router.java
+++ b/src/main/java/org/opentripplanner/standalone/Router.java
@@ -35,6 +35,7 @@ public class Router {
     public String id;
     public Graph graph;
     public double[] timeouts = {5, 4, 2};
+    public int mbtaShuttlePenalty = 300;
 
     /**
      *  Separate logger for incoming requests. This should be handled with a Logback logger rather than something
@@ -158,6 +159,15 @@ public class Router {
         JsonNode useFlexService = config.get("useFlexService");
         if (useFlexService != null) {
             graph.setUseFlexService(useFlexService.asBoolean(false));
+        }
+
+        JsonNode mbtaShuttlePenalty = config.get("mbtaShuttlePenalty");
+        if (mbtaShuttlePenalty != null) {
+            if (mbtaShuttlePenalty.isNumber()) {
+                this.mbtaShuttlePenalty = mbtaShuttlePenalty.intValue();
+            } else {
+                LOG.error("The 'mbtaShuttlePenalty' configuration option should be a number of seconds.");
+            }
         }
 
         /* Create Graph updater modules from JSON config. */

--- a/var/graphs/mbta/router-config.json
+++ b/var/graphs/mbta/router-config.json
@@ -1,6 +1,7 @@
 {
   "stopClusterMode": "parentStation",
   "useFlexService": "true",
+  "mbtaShuttlePenalty": 300,
   "updaters": [
     {
       "type": "real-time-alerts-enhanced",


### PR DESCRIPTION
Ticket: [🚍 OL shuttle priority in OTP](https://app.asana.com/0/810933294009540/1143319689013915/f)

Implemented the change as per ticket, though it's not going to change the fact that the shuttles are forced to be in the end of the list (see `AvoidShuttlesComparator` introduced in https://github.com/mbta/OpenTripPlanner/pull/25)