### PR TITLE
chore: Use google_transit GTFS feed

### DIFF
--- a/mbta/update_gtfs.sh
+++ b/mbta/update_gtfs.sh
@@ -4,5 +4,5 @@ set -e
 # it's important for MBTA_GFTS to be first file in the folder,
 # otherwise realtime alerts won't work: https://github.com/mbta/OpenTripPlanner/pull/8
 
-wget -N https://mbta-gtfs-s3.s3.amazonaws.com/open_trip_planner.zip -O var/graphs/mbta/1_MBTA_GTFS.zip
+wget -N https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip -O var/graphs/mbta/1_MBTA_GTFS.zip
 wget -N http://www.massport.com/media/4109/massport_gtfs.zip -O var/graphs/mbta/2_loganexpress-ma-us.zip


### PR DESCRIPTION
Asana task: [🚝 Remove OTP GTFS feed](https://app.asana.com/0/584764604969369/1183704546511331/f)

Switches from using an OTP-customized version of the MBTA's GTFS feed to using the Google Transit version, which are currently the same. This will allow us to eliminate the OTP GTFS export from https://github.com/mbta/gtfs_creator/.