### PR TITLE
Temporarily use old version of Logan GTFS

### DIFF
--- a/mbta/update_gtfs.sh
+++ b/mbta/update_gtfs.sh
@@ -5,4 +5,4 @@ set -e
 # otherwise realtime alerts won't work: https://github.com/mbta/OpenTripPlanner/pull/8
 
 wget -N https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip -O var/graphs/mbta/1_MBTA_GTFS.zip
-wget -N http://www.massport.com/media/4109/massport_gtfs.zip -O var/graphs/mbta/2_loganexpress-ma-us.zip
+wget -N https://mbta-gtfs-s3.s3.amazonaws.com/loganexpress_temp_gtfs.zip -O var/graphs/mbta/2_loganexpress-ma-us.zip


### PR DESCRIPTION
Asana ticket: [[extra] Temporarily use transitfeeds.com URL for Logan GTFS](https://app.asana.com/0/584764604969369/1186474869445339/f)

The version of the GTFS at Massport's URL is set to expire in the
past, meaning that we can't use it to plan any trips. I instead
pointed it to the latest version from transitfeeds.com, but
substituting the date of the feed for "latest" in the URL so that it
doesn't update out from under us.

This appears to just refernce the old Trillium GTFS feed but it seems
like transitfeeds.com may be less likely to change, especially if the
Trillium URL is deprecated by Massport now.