### PR TITLE
chore: go back to using MassPort's GTFS hosted on their site

### DIFF
--- a/mbta/update_gtfs.sh
+++ b/mbta/update_gtfs.sh
@@ -5,4 +5,4 @@ set -e
 # otherwise realtime alerts won't work: https://github.com/mbta/OpenTripPlanner/pull/8
 
 wget -N https://mbta-gtfs-s3.s3.amazonaws.com/google_transit.zip -O var/graphs/mbta/1_MBTA_GTFS.zip
-wget -N https://mbta-gtfs-s3.s3.amazonaws.com/loganexpress_temp_gtfs.zip -O var/graphs/mbta/2_loganexpress-ma-us.zip
+wget -N http://massport.com/media/4189/massport_gtfs-813.zip -O var/graphs/mbta/2_loganexpress-ma-us.zip


### PR DESCRIPTION
Asana ticket: [💳 Switch back to Massport GTFS feed](https://app.asana.com/0/584764604969369/1186477473280169/f)

Was able to plan a trip on the MassPort shuttles as represented in the GTFS file:

![Screen Shot 2020-10-01 at 10 25 19 AM](https://user-images.githubusercontent.com/2010157/94823075-6d326700-03d1-11eb-838a-957718f4bbf8.png)
